### PR TITLE
FD/ND split of detdataformats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(appfwk REQUIRED)
 find_package(logging REQUIRED)
 find_package(daqdataformats REQUIRED)
 find_package(detdataformats REQUIRED)
+find_package(fddetdataformats REQUIRED)
 find_package(readoutlibs REQUIRED)
 find_package(fdreadoutlibs REQUIRED)
 find_package(PkgConfig REQUIRED)
@@ -24,7 +25,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
 
 ##############################################################################
 # Dependency sets
-set(DUNEDAQ_DEPENDENCIES readoutlibs::readoutlibs daqdataformats::daqdataformats detdataformats::detdataformats fdreadoutlibs::fdreadoutlibs)
+set(DUNEDAQ_DEPENDENCIES readoutlibs::readoutlibs daqdataformats::daqdataformats detdataformats::detdataformats fddetdataformats::fddetdataformats fdreadoutlibs::fdreadoutlibs)
 
 # Provide override functionality for DPDK dependencies
 option(WITH_DPDK_AS_PACKAGE "DPDK externals as a dunedaq package" OFF)

--- a/cmake/dpdklibsConfig.cmake.in
+++ b/cmake/dpdklibsConfig.cmake.in
@@ -5,6 +5,8 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(appfwk)
 find_dependency(logging)
+find_dependency(detdataformats)
+find_dependency(fddetdataformats)
 find_dependency(daqdataformats)
 find_dependency(readout)
 #find_dependency(dpdk)

--- a/plugins/NICReceiver.hpp
+++ b/plugins/NICReceiver.hpp
@@ -17,7 +17,7 @@
 #include "iomanager/Sender.hpp"
 
 #include "readoutlibs/utils/ReusableThread.hpp"
-#include "detdataformats/tde/TDE16Frame.hpp"
+#include "fddetdataformats/TDE16Frame.hpp"
 
 #include "dpdklibs/nicreader/Structs.hpp"
 #include "dpdklibs/nicreaderinfo/InfoNljs.hpp"
@@ -53,7 +53,7 @@ public:
 private:
   // Types
   using module_conf_t = dunedaq::dpdklibs::nicreader::Conf;
-  using amc_frame_queue_t = folly::ProducerConsumerQueue<detdataformats::tde::TDE16Frame>;
+  using amc_frame_queue_t = folly::ProducerConsumerQueue<fddetdataformats::TDE16Frame>;
   using amc_frame_queue_ptr_t = std::unique_ptr<amc_frame_queue_t>;
 
   // Commands

--- a/plugins/NICSender.cpp
+++ b/plugins/NICSender.cpp
@@ -27,7 +27,7 @@
 #include <rte_udp.h>
 
 #include "dpdklibs/udp/PacketCtor.hpp"
-#include "detdataformats/tde/TDE16Frame.hpp"
+#include "fddetdataformats/TDE16Frame.hpp"
 
 #include "readoutlibs/utils/RateLimiter.hpp"
 
@@ -187,7 +187,7 @@ int lcore_main(void *arg)
 
   auto stats = std::thread([&]() {
     while (true) {
-      // TLOG() << "Rate is " << (sizeof(detdataformats::wib::WIBFrame) + sizeof(struct rte_ether_hdr)) * num_frames / 1e6 * 8;
+      // TLOG() << "Rate is " << (sizeof(fddetdataformats::WIBFrame) + sizeof(struct rte_ether_hdr)) * num_frames / 1e6 * 8;
       TLOG() << "Rate is " << (sizeof(T)+42) * num_frames / 1e6 * 8;
       num_frames.exchange(0);
       std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -352,7 +352,7 @@ NICSender::do_start(const data_t&)
 {
   m_run_mark.store(true);
   if (m_frontend_type == "tde") {
-    auto fun = &lcore_main<detdataformats::tde::TDE16Frame>;
+    auto fun = &lcore_main<fddetdataformats::TDE16Frame>;
     for (auto& [id, _] : m_core_map) {
         TLOG() << "Starting core " << id;
         rte_eal_remote_launch(fun, reinterpret_cast<void*>(this), id);

--- a/src/SourceModel.hpp
+++ b/src/SourceModel.hpp
@@ -116,7 +116,7 @@ public:
   /* 
   void
   NICReceiver::copy_out(int queue, char* message, std::size_t size) {
-    //detdataformats::tde::TDE16Frame target_payload;
+    //fddetdataformats::TDE16Frame target_payload;
   
     fdreadoutlibs::types::DUNEWIBEthTypeAdapter target_payload;
     uint32_t bytes_copied = 0;

--- a/test/apps/test_frame_transmitter.cxx
+++ b/test/apps/test_frame_transmitter.cxx
@@ -11,7 +11,7 @@
 #include <thread>
 
 #include "logging/Logging.hpp"
-#include "detdataformats/wib/WIBFrame.hpp"
+#include "fddetdataformats/WIBFrame.hpp"
 #include "dpdklibs/udp/PacketCtor.hpp"
 
 #define RX_RING_SIZE 1024
@@ -170,7 +170,7 @@ void lcore_main(void *arg) {
 
   auto stats = std::thread([&]() {
     while (true) {
-      // TLOG() << "Rate is " << (sizeof(detdataformats::wib::WIBFrame) + sizeof(struct rte_ether_hdr)) * num_frames / 1e6 * 8;
+      // TLOG() << "Rate is " << (sizeof(fddetdataformats::WIBFrame) + sizeof(struct rte_ether_hdr)) * num_frames / 1e6 * 8;
       TLOG() << "Rate is " << sizeof(struct ipv4_udp_packet) * num_frames / 1e6 * 8;
       num_frames.exchange(0);
       std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -197,7 +197,7 @@ void lcore_main(void *arg) {
 
       // Message struct
       // struct Message {
-      //   // detdataformats::wib::WIBFrame fr;
+      //   // fddetdataformats::WIBFrame fr;
       //   char ch[16];
       // };
 


### PR DESCRIPTION
As the first step of the FD/ND release split, `detdataformats` is split into several new packages:
1. `fddetdataformats`
2. `nddetdataformats`
3. `trgdataformats`

The split involves relocation of headers, rename of namespaces, and updates to C
MakeLists.txt and config.cmake.in

This PR contains the necessary changes as a result of the split.

