### PR TITLE
LCore sleep logic and multiprocess test

### DIFF
--- a/schema/dpdklibs/nicreader.jsonnet
+++ b/schema/dpdklibs/nicreader.jsonnet
@@ -33,6 +33,8 @@ local nicreader = {
 
     mac:    s.string("mac", pattern="^[a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5}$", doc="mac string"),
 
+    pcie: s.string("pcie", pattern="^(0{0,4}:[0-9]{2}:[0-9]{2}.[0-9])$", doc="pcie id string"),
+
     float : s.number("Float", "f4", doc="A float number"),
 
     stream_map : s.record("StreamMap", [
@@ -69,6 +71,7 @@ local nicreader = {
     iface : s.record("Interface", [
         s.field("mac_addr", self.mac, "AA:BB:CC:DD:EE:FF", doc="Logical Interface ID"),
         s.field("ip_addr", self.ipv4, "192.168.0.1", doc="IP address of interface"),
+        s.field("pci_dev_id", self.pcie, "0000:00:00.0", doc="PCIe device id"),
         s.field("with_flow_control", self.choice, true, doc="FlowAPI enabled"),
         s.field("promiscuous_mode", self.choice, false, doc="Promiscuous mode enabled"),
         s.field("mtu", self.count, 9000, doc="MTU of interface"),

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -25,10 +25,10 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
 
   // While loop of quit atomic member in IfaceWrapper
   while(!this->m_lcore_quit_signal.load()) {
+    uint8_t fb_count(0);
 
     // Loop over assigned queues to process
     for (auto q : queues) {
-      uint8_t fb_count(0);
       auto src_rx_q = q.first;
       auto* q_bufs = m_bufs[src_rx_q];
 
@@ -101,14 +101,14 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
         ++fb_count;
       }
 
-      // If no packets in burst...
-      if (!full_burst) {
-        // Sleep n nanoseconds... (value from config, timespec initialized in lcore first lines)
-        /*int response =*/ nanosleep(&sleep_request, nullptr);
-      }
-
     } // per queue
 
+    // If no packets in burst...
+    if (!fb_count) {
+      // Sleep n nanoseconds... (value from config, timespec initialized in lcore first lines)
+      /*int response =*/ nanosleep(&sleep_request, nullptr);
+    }
+    
   } // main while(quit) loop
  
   TLOG() << "LCore RX runner on CPU[" << lid << "] returned.";

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -96,12 +96,13 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
       } // per burst
 
       // Full burst counter
-      if (nb_rx == m_burst_size) {
+      bool full_burst = (nb_rx == m_burst_size);
+      if (full_burst) {
         ++fb_count;
       }
 
       // If no packets in burst...
-      if (!fb_count) {
+      if (!full_burst) {
         // Sleep n nanoseconds... (value from config, timespec initialized in lcore first lines)
         /*int response =*/ nanosleep(&sleep_request, nullptr);
       }

--- a/test/apps/test_multi_proc.cxx
+++ b/test/apps/test_multi_proc.cxx
@@ -13,6 +13,7 @@
 #include <rte_lcore.h>
 #include <rte_mbuf.h>
 #include <stdint.h>
+#include <unistd.h>
 #include <tuple>
 
 #include <csignal>
@@ -374,13 +375,15 @@ int main(int argc, char** argv){
     app.add_flag("-p", per_stream_reports, "Detailed per stream reports");
     CLI11_PARSE(app, argc, argv);
 
+    std::string file_prefix = fmt::format("if{}_rte",iface);
+
     //    define function to be called when ctrl+c is called.
     std::signal(SIGINT, signal_callback_handler);
     
     std::vector<std::string> eal_args;
     eal_args.push_back("dpdklibds_test_frame_receiver");
     eal_args.push_back("--proc-type=primary");
-    // eal_args.push_back(fmt::format("--file-prexix={}"));
+    eal_args.push_back(fmt::format("--file-prefix={}", file_prefix));
     if (!allow_dev.empty()) {
         eal_args.push_back(fmt::format("--allow={}",allow_dev));
     }
@@ -415,7 +418,9 @@ int main(int argc, char** argv){
 
     //std::this_thread::sleep_for(std::chrono::seconds(10));
 
-    //return 0;  
+    //return 0;
+    // Hack, force interface id = 0  
+    iface = 0;
 
     // Allocate pools and mbufs per queue
     std::map<int, std::unique_ptr<rte_mempool>> mbuf_pools;


### PR DESCRIPTION
1. Improved sleep logic. Sleep only once per iteration over all queues.
2. Added file-prefix option to the dpdk multiprocess test