### PR TITLE
Only sleep after checking all queues

### DIFF
--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -27,8 +27,8 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
   while(!this->m_lcore_quit_signal.load()) {
 
     // Loop over assigned queues to process
+    uint8_t fb_count(0);
     for (auto q : queues) {
-      uint8_t fb_count(0);
       auto src_rx_q = q.first;
       auto* q_bufs = m_bufs[src_rx_q];
 
@@ -99,14 +99,13 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
       if (nb_rx == m_burst_size) {
         ++fb_count;
       }
-
-      // If no packets in burst...
-      if (!fb_count) {
-        // Sleep n nanoseconds... (value from config, timespec initialized in lcore first lines)
-        /*int response =*/ nanosleep(&sleep_request, nullptr);
-      }
-
     } // per queue
+
+    // If no full buffers in burst...
+    if (!fb_count) {
+      // Sleep n nanoseconds... (value from config, timespec initialized in lcore first lines)
+      /*int response =*/ nanosleep(&sleep_request, nullptr);
+    }
 
   } // main while(quit) loop
  


### PR DESCRIPTION
Moved the sleep and full buffer counter, so that the sleep only occurs if no queues had a full buffer (rather than one sleep per queue)