### PR TITLE
Skipping nanosleep when sleep time set to 0

### DIFF
--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -103,8 +103,10 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
 
     // If no full buffers in burst...
     if (!fb_count) {
-      // Sleep n nanoseconds... (value from config, timespec initialized in lcore first lines)
-      /*int response =*/ nanosleep(&sleep_request, nullptr);
+      if (m_lcore_sleep_ns) {
+        // Sleep n nanoseconds... (value from config, timespec initialized in lcore first lines)
+        /*int response =*/ nanosleep(&sleep_request, nullptr);
+      }
     }
 
   } // main while(quit) loop


### PR DESCRIPTION
Due to the not-well-determined behaviour when calling `nanosleep`with 0 sleep.