### PR TITLE
Roland sipos/data move cb registry

### DIFF
--- a/plugins/NICReceiver.cpp
+++ b/plugins/NICReceiver.cpp
@@ -101,8 +101,12 @@ NICReceiver::init(const data_t& args)
         ers::fatal(dunedaq::readoutlibs::InitializationError(
           ERS_HERE, "Output link ID could not be parsed on queue instance name! "));
       }
-      TLOG() << "Creating source for target queue: " << target << " DLH number: " << sourceid;
-      m_sources[sourceid] = createSourceModel(qi.uid);
+      bool callback_mode = false;
+      if (words.front() == "cb") {
+        callback_mode = true;
+      }
+      TLOG() << "Creating source for target queue: " << target << " DLH number: " << sourceid << " CallbacksMode?=" << callback_mode;
+      m_sources[sourceid] = createSourceModel(qi.uid, callback_mode);
       if (m_sources[sourceid] == nullptr) {
         ers::fatal(dunedaq::readoutlibs::InitializationError(
           ERS_HERE, "CreateSource failed to provide an appropriate model for queue!"));

--- a/plugins/NICReceiver.cpp
+++ b/plugins/NICReceiver.cpp
@@ -210,6 +210,13 @@ NICReceiver::do_start(const data_t&)
   // } else {
   //   TLOG_DEBUG(5) << "NICReader is already running!";
   // }
+  //
+  
+  // Setup callbacks on all sourcemodels
+  for (auto& [sourceid, source] : m_sources) {
+    source->acquire_callback();
+  }
+
   for (auto& [iface_id, iface] : m_ifaces) {
     iface->enable_flow();
   }

--- a/src/CreateSource.hpp
+++ b/src/CreateSource.hpp
@@ -26,7 +26,7 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEFrameTypeAdapter, "TDEFram
 namespace dpdklibs {
 
 std::unique_ptr<SourceConcept>
-createSourceModel(const std::string& conn_uid)
+createSourceModel(const std::string& conn_uid, bool callback_mode)
 {
   auto datatypes = dunedaq::iomanager::IOManager::get()->get_datatypes(conn_uid);
   if (datatypes.size() != 1) {
@@ -45,7 +45,7 @@ createSourceModel(const std::string& conn_uid)
     source_model->set_sink_name(conn_uid);
 
     // Setup sink (acquire pointer from QueueRegistry)
-    source_model->set_sink(conn_uid);
+    source_model->set_sink(conn_uid, callback_mode);
 
     // Get parser and sink
     //auto& parser = source_model->get_parser();
@@ -65,7 +65,7 @@ createSourceModel(const std::string& conn_uid)
   } else if (raw_dt.find("TDEFrame") != std::string::npos) {
     // WIB2 specific char arrays
     auto source_model = std::make_unique<SourceModel<fdreadoutlibs::types::TDEFrameTypeAdapter>>();
-    source_model->set_sink(conn_uid);
+    source_model->set_sink(conn_uid, callback_mode);
     //auto& parser = source_model->get_parser();
     //parser.process_chunk_func = parsers::fixsizedChunkInto<fdreadoutlibs::types::DUNEWIBSuperChunkTypeAdapter>(sink);
     return source_model;

--- a/src/CreateSource.hpp
+++ b/src/CreateSource.hpp
@@ -41,6 +41,9 @@ createSourceModel(const std::string& conn_uid)
     // Create Model
     auto source_model = std::make_unique<SourceModel<fdreadoutlibs::types::DUNEWIBEthTypeAdapter>>();
 
+    // For callback acquisition later (lazy)
+    source_model->set_sink_name(conn_uid);
+
     // Setup sink (acquire pointer from QueueRegistry)
     source_model->set_sink(conn_uid);
 

--- a/src/SourceConcept.hpp
+++ b/src/SourceConcept.hpp
@@ -47,6 +47,7 @@ public:
 
   virtual void init(const nlohmann::json& args) = 0;
   virtual void set_sink(const std::string& sink_name) = 0;
+  virtual void acquire_callback() = 0;
   virtual void conf(const nlohmann::json& args) = 0;
   virtual void start(const nlohmann::json& args) = 0;
   virtual void stop(const nlohmann::json& args) = 0;
@@ -56,6 +57,11 @@ public:
   //virtual bool queue_in_block_address(uint64_t block_addr) = 0; // NOLINT
 
   //DefaultParserImpl& get_parser() { return std::ref(m_parser_impl); }
+
+  void set_sink_name(const std::string& sink_name) 
+  { 
+    m_sink_name = sink_name; 
+  }
 
   void set_ids(int card, int pid, int sip, int lid)
   {
@@ -92,6 +98,7 @@ protected:
   std::string m_source_str;
   std::string m_opmon_str;
   std::string m_source_tid;
+  std::string m_sink_name;
   std::chrono::time_point<std::chrono::high_resolution_clock> m_t0;
 
 private:

--- a/src/SourceConcept.hpp
+++ b/src/SourceConcept.hpp
@@ -46,7 +46,7 @@ public:
   SourceConcept& operator=(SourceConcept&&) = delete;      ///< SourceConcept is not move-assignable
 
   virtual void init(const nlohmann::json& args) = 0;
-  virtual void set_sink(const std::string& sink_name) = 0;
+  virtual void set_sink(const std::string& sink_name, bool callback_mode) = 0;
   virtual void acquire_callback() = 0;
   virtual void conf(const nlohmann::json& args) = 0;
   virtual void start(const nlohmann::json& args) = 0;

--- a/src/SourceModel.hpp
+++ b/src/SourceModel.hpp
@@ -136,19 +136,18 @@ public:
     bool push_out = true;
     if (push_out) {
 
-////////////////////////////////////
-// RS FIXME: Non optional callbacks. This version only works with callbacks setup.
       TargetPayloadType& target_payload = *reinterpret_cast<TargetPayloadType*>(message);
-      (*m_sink_callback)(std::move(target_payload));
-/*
-      if (!m_sink_queue->try_send(std::move(target_payload), iomanager::Sender::s_no_block)) {
-        //if(m_dropped_packets == 0 || m_dropped_packets%10000) {
-        //  TLOG() << "Dropped data " << m_dropped_packets;
-        //}
-        ++m_dropped_packets;
+
+      if (m_callback_mode) {
+        (*m_sink_callback)(std::move(target_payload));
+      } else {
+        if (!m_sink_queue->try_send(std::move(target_payload), iomanager::Sender::s_no_block)) {
+          //if(m_dropped_packets == 0 || m_dropped_packets%10000) {
+          //  TLOG() << "Dropped data " << m_dropped_packets;
+          //}
+          ++m_dropped_packets;
+        }
       }
-*/
-///////////////////////////////////
 
     } else {
       TargetPayloadType target_payload;


### PR DESCRIPTION
This branch makes it possible to move data between I/O card receivers (e.g.: NICReceiver) through callback invokation, instead of IOManager (that bring an extra data copy of the full stream).
The option is enabled, if the "cb_" prefix is appended for the "raw_input" connection names in the init step of the DataLinkHandler modules.

Dependency PR is in `readoutlibs`: 
https://github.com/DUNE-DAQ/readoutlibs/pull/164