### PR TITLE
Ensuring that eal_init failure makes the module to go into error

### DIFF
--- a/plugins/NICReceiver.cpp
+++ b/plugins/NICReceiver.cpp
@@ -191,8 +191,8 @@ NICReceiver::do_configure(const data_t& /*args*/)
        m_ifaces[interface->get_rx_iface()]->setup_xstats();
     } else {
        TLOG() << "No available interface with MAC=" << interface->get_rx_mac();
-       ers::fatal(dunedaq::readoutlibs::InitializationError(
-          ERS_HERE, "NICReceiver configuration failed due expected but unavailable interface!"));
+       throw dunedaq::readoutlibs::InitializationError(
+          ERS_HERE, "NICReceiver configuration failed due expected but unavailable interface!");
     }
   }
   


### PR DESCRIPTION
Replaced `ers::fatal` with `throw` when `eal_init` fails, to make the `conf` command to fail