### PR TITLE
Restored ARP support and improved main core handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ daq_add_application(dpdklibs_test_eal test_eal_app.cxx TEST LINK_LIBRARIES dpdkl
 daq_add_application(dpdklibs_test_frame_transmitter test_frame_transmitter.cxx TEST LINK_LIBRARIES dpdklibs CLI11::CLI11 ${DPDK_LIBRARIES} )
 daq_add_application(dpdklibs_test_frame_receiver test_frame_receiver.cxx TEST LINK_LIBRARIES dpdklibs CLI11::CLI11 ${DPDK_LIBRARIES} opmonlib::opmonlib)
 daq_add_application(dpdklibs_test_garp test_garp.cxx TEST LINK_LIBRARIES dpdklibs CLI11::CLI11 ${DPDK_LIBRARIES} )
-daq_add_application(dpdklibs_test_arp_response test_arp_response.cxx TEST LINK_LIBRARIES dpdklibs ${DPDK_LIBRARIES})
+daq_add_application(dpdklibs_test_arp_response test_arp_response.cxx TEST LINK_LIBRARIES dpdklibs CLI11::CLI11 ${DPDK_LIBRARIES})
 daq_add_application(dpdklibs_test_transmit_and_receive test_transmit_and_receive.cxx TEST LINK_LIBRARIES dpdklibs CLI11::CLI11 ${DPDK_LIBRARIES})
 daq_add_application(dpdklibs_test_dpdk_stats test_dpdk_stats.cxx TEST LINK_LIBRARIES dpdklibs CLI11::CLI11 ${DPDK_LIBRARIES})
 daq_add_application(dpdklibs_test_multi_process test_multi_proc.cxx TEST LINK_LIBRARIES dpdklibs CLI11::CLI11 ${DPDK_LIBRARIES})

--- a/include/dpdklibs/FlowControl.hpp
+++ b/include/dpdklibs/FlowControl.hpp
@@ -27,6 +27,9 @@ generate_ipv4_flow(uint16_t port_id, uint16_t rx_q,
 struct rte_flow *
 generate_drop_flow(uint16_t port_id, struct rte_flow_error *error);
 
+struct rte_flow *
+generate_arp_flow(uint16_t port_id, uint16_t rx_q, struct rte_flow_error *error);
+
 } // namespace dpdklibs
 } // namespace dunedaq
 

--- a/include/dpdklibs/Issues.hpp
+++ b/include/dpdklibs/Issues.hpp
@@ -25,11 +25,16 @@ ERS_DECLARE_ISSUE(dpdklibs,
                   ((int)ifaceid)
                 );
 
-
 ERS_DECLARE_ISSUE(dpdklibs,
                   LinkOffline,
                   "Link offline for interface [" << ifaceid << "]",
                   ((int)ifaceid)
+                );
+
+ERS_DECLARE_ISSUE(dpdklibs,
+                  MainCoreConflict,
+                  "The main core [" << main_core << "] conflicts with the worker cores list ",
+                  ((int)main_core)
                 );
 
 ERS_DECLARE_ISSUE(dpdklibs,

--- a/plugins/DPDKReaderModule.cpp
+++ b/plugins/DPDKReaderModule.cpp
@@ -144,7 +144,6 @@ DPDKReaderModule::do_configure(const data_t& /*args*/)
   bool is_first_pcie_addr = true;
   std::vector<uint16_t> rte_cores;
 
-  // FIXME: Hardcoding core 0 for GARP. Replace with better param.
   rte_cores.push_back(0);
 
   std::vector<const confmodel::DetectorToDaqConnection*> d2d_conns;

--- a/plugins/DPDKReaderModule.cpp
+++ b/plugins/DPDKReaderModule.cpp
@@ -29,6 +29,7 @@
 #include "dpdklibs/udp/Utils.hpp"
 #include "dpdklibs/udp/PacketCtor.hpp"
 #include "dpdklibs/FlowControl.hpp"
+#include "dpdklibs/Issues.hpp"
 #include "CreateSource.hpp"
 #include "DPDKReaderModule.hpp"
 
@@ -94,7 +95,7 @@ DPDKReaderModule::init(const std::shared_ptr<appfwk::ModuleConfiguration> mcfg )
  auto mdal = mcfg->module<appmodel::DataReaderModule>(get_name());
  m_cfg = mcfg;
  if (mdal->get_outputs().empty()) {
-   auto err = dunedaq::datahandlinglibs::InitializationError(ERS_HERE, "No outputs defined for NIC reader in configuration.");
+   auto err = datahandlinglibs::InitializationError(ERS_HERE, "No outputs defined for NIC reader in configuration.");
    ers::fatal(err);
    throw err;
  }
@@ -102,7 +103,7 @@ DPDKReaderModule::init(const std::shared_ptr<appfwk::ModuleConfiguration> mcfg )
  for (auto con : mdal->get_outputs()) {
   auto queue = con->cast<confmodel::QueueWithSourceId>();
   if(queue == nullptr) {
-	  auto err = dunedaq::datahandlinglibs::InitializationError(ERS_HERE, "Outputs are not of type QueueWithGeoId.");
+	  auto err = datahandlinglibs::InitializationError(ERS_HERE, "Outputs are not of type QueueWithGeoId.");
 	  ers::fatal(err);
 	  throw err;
   }
@@ -142,15 +143,13 @@ DPDKReaderModule::do_configure(const data_t& /*args*/)
   // Construct the pcie devices allowed mask
   std::string first_pcie_addr;
   bool is_first_pcie_addr = true;
-  std::vector<uint16_t> rte_cores;
-
-  rte_cores.push_back(0);
+  std::deque<uint16_t> rte_cores;
 
   std::vector<const confmodel::DetectorToDaqConnection*> d2d_conns;
   for (auto res : res_set) {
     auto connection = res->cast<confmodel::DetectorToDaqConnection>();
     if (connection == nullptr) {
-      dunedaq::datahandlinglibs::GenericConfigurationError err(
+      datahandlinglibs::GenericConfigurationError err(
           ERS_HERE, "DetectorToDaqConnection configuration failed due expected but unavailable connection!"
         );
       ers::fatal(err);
@@ -164,7 +163,7 @@ DPDKReaderModule::do_configure(const data_t& /*args*/)
 
     auto receiver = connection->get_receiver()->cast<appmodel::DPDKReceiver>();
     if (!receiver) {
-      throw dunedaq::datahandlinglibs::InitializationError(
+      throw datahandlinglibs::InitializationError(
         ERS_HERE, fmt::format("Found {} of type {} in connection {} while expecting type DPDKReceiver", receiver->class_name(), receiver->UID(), connection->UID())
       );
     }
@@ -182,6 +181,12 @@ DPDKReaderModule::do_configure(const data_t& /*args*/)
       rte_cores.insert(rte_cores.end(), proc_res->get_cpu_cores().begin(), proc_res->get_cpu_cores().end());
     }
   }
+
+  uint16_t main_core = rte_get_main_lcore();
+  if (std::find(rte_cores.begin(), rte_cores.end(), main_core) != rte_cores.end()) {
+    throw MainCoreConflict(ERS_HERE, main_core);
+  }
+  rte_cores.push_front(main_core);
 
   eal_params.push_back("-l");
   eal_params.push_back(fmt::format("{}", fmt::join(rte_cores,",")));
@@ -215,7 +220,7 @@ DPDKReaderModule::do_configure(const data_t& /*args*/)
     for ( auto sender : d2d_conn->get_senders() ) {
       auto nw_sender = sender->cast<appmodel::NWDetDataSender>();
       if ( !nw_sender ) {
-        throw dunedaq::datahandlinglibs::InitializationError(
+        throw datahandlinglibs::InitializationError(
           ERS_HERE, fmt::format("Found {} of type {} in connection {} while expecting type NWDetDataSender", dpdk_receiver->class_name(), dpdk_receiver->UID(), d2d_conn->UID())
         );
       }
@@ -230,7 +235,7 @@ DPDKReaderModule::do_configure(const data_t& /*args*/)
     
     if ((m_mac_to_id_map.count(net_device->get_mac_address()) == 0) || (m_pci_to_id_map.count(net_device->get_pcie_addr()) == 0)) {
         TLOG() << "No available interface with MAC=" << net_device->get_mac_address();
-        throw dunedaq::datahandlinglibs::InitializationError(
+        throw datahandlinglibs::InitializationError(
           ERS_HERE, "DPDKReaderModule configuration failed due expected but unavailable interface!"
         );
     }

--- a/src/CreateSource.hpp
+++ b/src/CreateSource.hpp
@@ -13,7 +13,7 @@
 #include "datahandlinglibs/DataHandlingIssues.hpp"
 
 #include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
-#include "fdreadoutlibs/TDEFrameTypeAdapter.hpp"
+#include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
 
 #include <memory>
 #include <string>
@@ -21,7 +21,7 @@
 namespace dunedaq {
 
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter, "WIBEthFrame")
-DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEFrameTypeAdapter, "TDEFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter, "TDEEthFrame")
 
 namespace dpdklibs {
 
@@ -62,9 +62,9 @@ createSourceModel(const std::string& conn_uid, bool callback_mode)
     // Return with setup model
     return source_model;
 
-  } else if (raw_dt.find("TDEFrame") != std::string::npos) {
+  } else if (raw_dt.find("TDEEthFrame") != std::string::npos) {
     // WIB2 specific char arrays
-    auto source_model = std::make_shared<SourceModel<fdreadoutlibs::types::TDEFrameTypeAdapter>>();
+    auto source_model = std::make_shared<SourceModel<fdreadoutlibs::types::TDEEthTypeAdapter>>();
     source_model->set_sink_name(conn_uid);
     source_model->set_sink(conn_uid, callback_mode);
     //auto& parser = source_model->get_parser();

--- a/src/EALSetup.cpp
+++ b/src/EALSetup.cpp
@@ -143,6 +143,8 @@ iface_init(uint16_t iface, uint16_t rx_rings, uint16_t tx_rings,
     }
   }
 
+  TLOG() << "Configuring Iface " << iface << " rx rings: " << rx_rings <<", tx rings " << tx_rings;
+
   // Configure the Ethernet interface
   if ((retval = rte_eth_dev_configure(iface, rx_rings, tx_rings, &iface_conf)) != 0) {
     throw FailedToConfigureInterface(ERS_HERE, iface, "Device Configuration", retval);

--- a/src/FlowControl.cpp
+++ b/src/FlowControl.cpp
@@ -6,6 +6,9 @@
 
 #include "logging/Logging.hpp"
 
+#include <rte_byteorder.h>
+#include <rte_ether.h>
+#include <rte_flow.h>
 #include <rte_ip.h>
 
 namespace dunedaq {
@@ -157,6 +160,52 @@ generate_drop_flow(uint16_t port_id, struct rte_flow_error *error)
   	flow = rte_flow_create(port_id, &attr, pattern, action, error);
   }
   
+  return flow;
+}
+
+// ARP packets to specific 
+struct rte_flow *
+generate_arp_flow(uint16_t port_id, uint16_t rx_q, struct rte_flow_error *error)
+{
+  struct rte_flow_attr attr;
+  struct rte_flow_item pattern[MAX_PATTERN_NUM];
+  struct rte_flow_action action[MAX_ACTION_NUM];
+  struct rte_flow *flow = NULL;
+  struct rte_flow_action_queue queue = { .index = rx_q };
+  int res;
+
+  memset(pattern, 0, sizeof(pattern));
+  memset(action, 0, sizeof(action));
+
+  // Set the rule attribute, only ingress packets will be checked.
+  memset(&attr, 0, sizeof(struct rte_flow_attr));
+  attr.ingress = 1;
+  attr.egress = 0;
+  attr.priority = 1; // TODO the higher the lower?
+
+  // Action -> queue steering
+  action[0].type = RTE_FLOW_ACTION_TYPE_QUEUE;
+  action[0].conf = &queue;
+  action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+  // Rule prep
+  struct rte_flow_item_eth  item_eth_mask = {};
+  struct rte_flow_item_eth  item_eth_spec = {};
+  // Rule marker
+  item_eth_spec.hdr.ether_type = RTE_BE16(RTE_ETHER_TYPE_ARP);
+  item_eth_mask.hdr.ether_type = RTE_BE16(0xFFFF);
+  // Rule pattern
+  pattern[0].type = RTE_FLOW_ITEM_TYPE_ETH;
+  pattern[0].mask = &item_eth_mask;
+  pattern[0].spec = &item_eth_spec;
+  pattern[1].type = RTE_FLOW_ITEM_TYPE_END;
+
+    // Validate the rule and create it.
+  res = rte_flow_validate(port_id, &attr, pattern, action, error);
+  if (not res) {
+    flow = rte_flow_create(port_id, &attr, pattern, action, error);
+  }
+
   return flow;
 }
 

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -311,16 +311,6 @@ IfaceWrapper::start()
   TLOG() << "Interface id=" << m_iface_id <<" Launching GARP thread with garp_func...";
   m_garp_thread = std::thread(&IfaceWrapper::garp_func, this);
   
-  // unsigned lcore_id;
-
-  // TLOG() << "Interface id=" << m_iface_id << " starting ARP LCore processor:";
-  // // int ret = rte_eal_remote_launch((int (*)(void*))(&IfaceWrapper::arp_response_runner), this, 0);
-  // RTE_LCORE_FOREACH_WORKER(lcore_id) {
-  //   // rte_eal_remote_launch(worker_fn, NULL, lcore_id);
-  //   int ret = rte_eal_remote_launch((int (*)(void*))(&IfaceWrapper::arp_response_runner), this, lcore_id);
-  //   TLOG() << "  -> ARP LCore[" << lcore_id << "] launched with return code=" << -ret;
-  // }
-
   TLOG() << "Interface id=" << m_iface_id << " starting ARP LCore processor:";
   m_arp_thread = std::thread(&IfaceWrapper::IfaceWrapper::arp_response_runner, this, nullptr);
 

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -76,10 +76,10 @@ IfaceWrapper::IfaceWrapper(
   for( const std::string& ip_addr : m_ip_addr) {
     IpAddr ip_addr_struct(ip_addr);
     m_ip_addr_bin.push_back(udp::ip_address_dotdecimal_to_binary(
-        ip_addr_struct.addr_bytes[3],
-        ip_addr_struct.addr_bytes[2],
+        ip_addr_struct.addr_bytes[0],
         ip_addr_struct.addr_bytes[1],
-        ip_addr_struct.addr_bytes[0]
+        ip_addr_struct.addr_bytes[2],
+        ip_addr_struct.addr_bytes[3]
     ));
   } 
 
@@ -311,14 +311,23 @@ IfaceWrapper::start()
   TLOG() << "Launching GARP thread with garp_func...";
   m_garp_thread = std::thread(&IfaceWrapper::garp_func, this);
   
-  TLOG() << "Interface id=" << m_iface_id << " starting ARP LCore processor:";
-  int ret = rte_eal_remote_launch((int (*)(void*))(&IfaceWrapper::arp_response_runner), this, 0);
-  TLOG() << "  -> ARP LCore[0] launched with return code=" << ret;
+  // unsigned lcore_id;
+
+  // TLOG() << "Interface id=" << m_iface_id << " starting ARP LCore processor:";
+  // // int ret = rte_eal_remote_launch((int (*)(void*))(&IfaceWrapper::arp_response_runner), this, 0);
+  // RTE_LCORE_FOREACH_WORKER(lcore_id) {
+  //   // rte_eal_remote_launch(worker_fn, NULL, lcore_id);
+  //   int ret = rte_eal_remote_launch((int (*)(void*))(&IfaceWrapper::arp_response_runner), this, lcore_id);
+  //   TLOG() << "  -> ARP LCore[" << lcore_id << "] launched with return code=" << -ret;
+  // }
+
+  m_arp_thread = std::thread(&IfaceWrapper::IfaceWrapper::arp_response_runner, this, nullptr);
+
 
   TLOG() << "Interface id=" << m_iface_id << " starting LCore processors:";
   for (auto const& [lcoreid, _] : m_rx_core_map) {
     int ret = rte_eal_remote_launch((int (*)(void*))(&IfaceWrapper::rx_runner), this, lcoreid);
-    TLOG() << "  -> LCore[" << lcoreid << "] launched with return code=" << ret;
+    TLOG() << "  -> LCore[" << lcoreid << "] launched with return code=" << ret << "   " << (ret < 0 ? rte_strerror(-ret) : "");
   }
 }
 
@@ -331,6 +340,12 @@ IfaceWrapper::stop()
   // Stop GARP sender thread  
   if (m_garp_thread.joinable()) {
     m_garp_thread.join();
+  } else {
+    TLOG() << "GARP thrad is not joinable!";
+  }
+
+  if (m_arp_thread.joinable()) {
+    m_arp_thread.join();
   } else {
     TLOG() << "GARP thrad is not joinable!";
   }

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -245,7 +245,7 @@ IfaceWrapper::setup_flow_steering()
   if (not flow) { // ers::fatal
         TLOG() << "ARP flow  can't be created for " << m_arp_rx_queue
          << " Error type: " << (unsigned)error.type
-         << " Message: " << error.message;
+         << " Message: '" << error.message << "'";
         ers::fatal(dunedaq::datahandlinglibs::InitializationError(
           ERS_HERE, "Couldn't create ARP flow API rules!"));
         rte_exit(EXIT_FAILURE, "error in creating ARP flow");
@@ -269,7 +269,7 @@ IfaceWrapper::setup_flow_steering()
       if (not flow) { // ers::fatal
         TLOG() << "Flow can't be created for " << rxqid
          << " Error type: " << (unsigned)error.type
-         << " Message: " << error.message;
+         << " Message: '" << error.message << "'";
         ers::fatal(dunedaq::datahandlinglibs::InitializationError(
           ERS_HERE, "Couldn't create Flow API rules!"));
         rte_exit(EXIT_FAILURE, "error in creating flow");

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -40,6 +40,7 @@
 #include <memory>
 #include <string>
 #include <regex>
+#include <stdexcept>
 
 /**
  * @brief TRACE debug levels used in this source file
@@ -104,6 +105,10 @@ IfaceWrapper::IfaceWrapper(
   for( const auto* proc_res : iface_cfg->get_used_lcores()) {
     m_rte_cores.insert(m_rte_cores.end(), proc_res->get_cpu_cores().begin(), proc_res->get_cpu_cores().end());
   }
+  if(std::find(m_rte_cores.begin(), m_rte_cores.end(), 0)!=m_rte_cores.end()) {
+    TLOG() << "ERROR! Throw ERS error here that LCore=0 should not be used, as it's a control RTE core!";
+    throw std::runtime_error(std::string("ERROR! Throw ERS here that LCore=0 should not be used, as it's a control RTE core!"));
+  }
 
   // iterate through active streams
 
@@ -125,7 +130,8 @@ IfaceWrapper::IfaceWrapper(
 
   }
 
-  uint32_t core_idx(0), rx_q(0);
+// RS FIXME: Is this RX_Q bump is enough??? I don't remember how the RX_Qs are assigned... 
+  uint32_t core_idx(0), rx_q(1); // RS FIXME: Ensure that no RX_Q=0 is used for UDP RX, ever.
   for( const auto& [tx_ip, strm_src] : ip_to_stream_src_groups) {
     m_ips.insert(tx_ip);
     m_rx_qs.insert(rx_q);
@@ -173,23 +179,35 @@ IfaceWrapper::~IfaceWrapper()
 void
 IfaceWrapper::allocate_mbufs() 
 {
-  TLOG() << "Allocating pools and mbufs.";
+  TLOG() << "Allocating pools and mbufs for UDP, GARP, and ARP.";
+
+  // Pools for UDP RX messages 
   for (size_t i=0; i<m_rx_qs.size(); ++i) {
-    std::stringstream ss;
-    ss << "MBP-" << m_iface_id << '-' << i;
-    TLOG() << "Acquire pool with name=" << ss.str() << " for iface_id=" << m_iface_id << " rxq=" << i;
-    m_mbuf_pools[i] = ealutils::get_mempool(ss.str(), m_num_mbufs, m_mbuf_cache_size, 16384, m_socket_id);
+    std::stringstream bufss;
+    bufss << "MBP-" << m_iface_id << '-' << i;
+    TLOG() << "Acquire pool with name=" << bufss.str() << " for iface_id=" << m_iface_id << " rxq=" << i;
+    m_mbuf_pools[i] = ealutils::get_mempool(bufss.str(), m_num_mbufs, m_mbuf_cache_size, 16384, m_socket_id);
     m_bufs[i] = (rte_mbuf**) malloc(sizeof(struct rte_mbuf*) * m_burst_size);
     // No need to alloc?
     // rte_pktmbuf_alloc_bulk(m_mbuf_pools[i].get(), m_bufs[i], m_burst_size);
   }
 
-  std::stringstream ss;
-  ss << "GARPMBP-" << m_iface_id;
-  TLOG() << "Acquire GARP pool with name=" << ss.str() << " for iface_id=" << m_iface_id;
-  m_garp_mbuf_pool = ealutils::get_mempool(ss.str());
+  // Pools for GARP messages
+  std::stringstream garpss;
+  garpss << "GARPMBP-" << m_iface_id;
+  TLOG() << "Acquire GARP pool with name=" << garpss.str() << " for iface_id=" << m_iface_id;
+  m_garp_mbuf_pool = ealutils::get_mempool(garpss.str());
   m_garp_bufs[0] = (rte_mbuf**) malloc(sizeof(struct rte_mbuf*) * m_burst_size);
   rte_pktmbuf_alloc_bulk(m_garp_mbuf_pool.get(), m_garp_bufs[0], m_burst_size);
+
+  // Pools for ARP request/responses
+  std::stringstream arpss;
+  arpss << "ARPMBP-" << m_iface_id;
+  TLOG() << "Acquire ARP pool with name=" << arpss.str() << " for iface_id=" << m_iface_id;
+  m_arp_mbuf_pool = ealutils::get_mempool(arpss.str());
+  m_arp_bufs[0] = (rte_mbuf**) malloc(sizeof(struct rte_mbuf*) * m_burst_size);
+  rte_pktmbuf_alloc_bulk(m_arp_mbuf_pool.get(), m_arp_bufs[0], m_burst_size);
+
 }
 
 
@@ -221,6 +239,19 @@ IfaceWrapper::setup_flow_steering()
   TLOG() << "Attempt to flush previous flow rules...";
   rte_flow_flush(m_iface_id, &error);
 #warning RS: FIXME -> Check for flow flush return!
+
+  TLOG() << "Create control flow rules (ARP).";
+	flow = generate_arp_flow(m_iface_id, m_arp_rx_queue, &error);
+  if (not flow) { // ers::fatal
+        TLOG() << "ARP flow  can't be created for " << m_arp_rx_queue
+         << " Error type: " << (unsigned)error.type
+         << " Message: " << error.message;
+        ers::fatal(dunedaq::datahandlinglibs::InitializationError(
+          ERS_HERE, "Couldn't create ARP flow API rules!"));
+        rte_exit(EXIT_FAILURE, "error in creating ARP flow");
+      }
+
+  TLOG() << "Create flow rules for UDP RX.";
   for (auto const& [lcoreid, rxqs] : m_rx_core_map) {
     for (auto const& [rxqid, srcip] : rxqs) {
       // Put the IP numbers temporarily in a vector, so they can be converted easily to uint32_t
@@ -269,13 +300,15 @@ IfaceWrapper::start()
     m_num_full_bursts[rx_q] = { 0 };
     m_max_burst_size[rx_q] = { 0 };
   }
-  
-  
+
   m_lcore_enable_flow.store(false);
   m_lcore_quit_signal.store(false);
   TLOG() << "Launching GARP thread with garp_func...";
   m_garp_thread = std::thread(&IfaceWrapper::garp_func, this);
   
+  TLOG() << "Interface id=" << m_iface_id << " starting ARP LCore processor:";
+  int ret = rte_eal_remote_launch((int (*)(void*))(&IfaceWrapper::arp_response_runner), this, 0);
+  TLOG() << "  -> ARP LCore[0] launched with return code=" << ret;
 
   TLOG() << "Interface id=" << m_iface_id << " starting LCore processors:";
   for (auto const& [lcoreid, _] : m_rx_core_map) {

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -105,7 +105,7 @@ IfaceWrapper::IfaceWrapper(
   for( const auto* proc_res : iface_cfg->get_used_lcores()) {
     m_rte_cores.insert(m_rte_cores.end(), proc_res->get_cpu_cores().begin(), proc_res->get_cpu_cores().end());
   }
-  if(std::find(m_rte_cores.begin(), m_rte_cores.end(), 0)!=m_rte_cores.end()) {
+  if(std::find(m_rte_cores.begin(), m_rte_cores.end(), rte_get_main_lcore())!=m_rte_cores.end()) {
     TLOG() << "ERROR! Throw ERS error here that LCore=0 should not be used, as it's a control RTE core!";
     throw std::runtime_error(std::string("ERROR! Throw ERS here that LCore=0 should not be used, as it's a control RTE core!"));
   }

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -131,7 +131,12 @@ IfaceWrapper::IfaceWrapper(
   }
 
 // RS FIXME: Is this RX_Q bump is enough??? I don't remember how the RX_Qs are assigned... 
-  uint32_t core_idx(0), rx_q(1); // RS FIXME: Ensure that no RX_Q=0 is used for UDP RX, ever.
+  uint32_t core_idx(0), rx_q(0); // RS FIXME: Ensure that no RX_Q=0 is used for UDP RX, ever.
+
+  m_rx_qs.insert(rx_q);
+  m_arp_rx_queue = rx_q;
+  ++rx_q;
+
   for( const auto& [tx_ip, strm_src] : ip_to_stream_src_groups) {
     m_ips.insert(tx_ip);
     m_rx_qs.insert(rx_q);
@@ -240,7 +245,7 @@ IfaceWrapper::setup_flow_steering()
   rte_flow_flush(m_iface_id, &error);
 #warning RS: FIXME -> Check for flow flush return!
 
-  TLOG() << "Create control flow rules (ARP).";
+  TLOG() << "Create control flow rules (ARP) assinged to rxq=" << m_arp_rx_queue;
 	flow = generate_arp_flow(m_iface_id, m_arp_rx_queue, &error);
   if (not flow) { // ers::fatal
         TLOG() << "ARP flow  can't be created for " << m_arp_rx_queue

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -308,7 +308,7 @@ IfaceWrapper::start()
 
   m_lcore_enable_flow.store(false);
   m_lcore_quit_signal.store(false);
-  TLOG() << "Launching GARP thread with garp_func...";
+  TLOG() << "Interface id=" << m_iface_id <<" Launching GARP thread with garp_func...";
   m_garp_thread = std::thread(&IfaceWrapper::garp_func, this);
   
   // unsigned lcore_id;
@@ -321,6 +321,7 @@ IfaceWrapper::start()
   //   TLOG() << "  -> ARP LCore[" << lcore_id << "] launched with return code=" << -ret;
   // }
 
+  TLOG() << "Interface id=" << m_iface_id << " starting ARP LCore processor:";
   m_arp_thread = std::thread(&IfaceWrapper::IfaceWrapper::arp_response_runner, this, nullptr);
 
 
@@ -341,13 +342,13 @@ IfaceWrapper::stop()
   if (m_garp_thread.joinable()) {
     m_garp_thread.join();
   } else {
-    TLOG() << "GARP thrad is not joinable!";
+    TLOG() << "GARP thread is not joinable!";
   }
 
   if (m_arp_thread.joinable()) {
     m_arp_thread.join();
   } else {
-    TLOG() << "GARP thrad is not joinable!";
+    TLOG() << "ARP thread is not joinable!";
   }
 }
 /*

--- a/src/IfaceWrapper.hpp
+++ b/src/IfaceWrapper.hpp
@@ -108,6 +108,7 @@ private:
 
   // CPU core ID -> [queue -> ip]
   std::map<int, std::map<int, std::string>> m_rx_core_map;
+  unsigned m_arp_rx_queue = 0; // RS TODO: make it configurable, and queue use conf check for exclusiveness!
 
   // Lcore stop signal
   std::atomic<bool> m_lcore_quit_signal{ false };
@@ -143,8 +144,16 @@ private:
   void garp_func();
   std::atomic<uint64_t> m_garps_sent{0};
 
+  // ARP
+  std::unique_ptr<rte_mempool> m_arp_mbuf_pool;
+  std::map<int, struct rte_mbuf **> m_arp_bufs;
+  std::thread m_arp_thread;
+  void arp_func();
+  std::atomic<uint64_t> m_arps_sent{0};
+
   // Lcore processor
   int rx_runner(void *arg __rte_unused);
+  int arp_response_runner(void *arg __rte_unused);
 
   // What to do with every payload
   void handle_eth_payload(int src_rx_q, char* payload, std::size_t size);

--- a/src/arp/ARP.cpp
+++ b/src/arp/ARP.cpp
@@ -20,7 +20,7 @@ namespace dpdklibs {
 namespace arp {
 
 void 
-pktgen_send_garp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t binary_ip_address)
+pktgen_send_garp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t ip_add_bin)
 {
   struct rte_ether_hdr *eth = rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
   struct rte_arp_hdr *arp = (struct rte_arp_hdr *)&eth[1];
@@ -38,7 +38,7 @@ pktgen_send_garp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t binary_ip_addr
   memset(arp, 0, sizeof(struct rte_arp_hdr));
   rte_memcpy(&arp->arp_data.arp_sha, &mac_addr, 6);
   
-  uint32_t addr = htonl(binary_ip_address);
+  uint32_t addr = htonl(ip_add_bin);
   inetAddrCopy(&arp->arp_data.arp_sip, &addr);
 
   //if (likely(type == GRATUITOUS_ARP) ) {
@@ -74,7 +74,7 @@ hex_digits_to_stream(std::ostringstream& ostrs, int value, char separator = ':',
 
 
 void
-pktgen_process_arp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t binary_ip_address)
+pktgen_process_arp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t ip_add_bin)
 {
   /*port_info_t   *info = &pktgen.info[port_id];*/
   /*pkt_seq_t     *pkt;*/
@@ -94,29 +94,17 @@ pktgen_process_arp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t binary_ip_ad
     struct rte_ether_addr mac_addr;
     rte_eth_macaddr_get(port_id, &mac_addr);
 
-    std::ostringstream ostrs;
-    ostrs << "dst mac addr: ";
-    hex_digits_to_stream(ostrs, (int)mac_addr.addr_bytes[0]);
-    hex_digits_to_stream(ostrs, (int)mac_addr.addr_bytes[1]);
-    hex_digits_to_stream(ostrs, (int)mac_addr.addr_bytes[2]);
-    hex_digits_to_stream(ostrs, (int)mac_addr.addr_bytes[3]);
-    hex_digits_to_stream(ostrs, (int)mac_addr.addr_bytes[4]);
-    hex_digits_to_stream(ostrs, (int)mac_addr.addr_bytes[5], '\n');
-    //std::cout << "DST MAC: " << ostrs.str();
-
-    /* ARP request not for this interface. */
-    //if (likely(pkt != NULL) ) {
-
-    //if (unlikely(arp->arp_data.arp_tip == mac_addr)) { //binary_ip_address)) {
-
-      
-
-      printf("ARP Received %i, local %i - I'm the target\n", ntohl(arp->arp_data.arp_tip), ntohl(binary_ip_address));
-
       std::string srcaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp->arp_data.arp_sip)));
-      //std::cout << "SRC IP: " << srcaddr << '\n';
+      std::cout << "SRC IP: " << srcaddr << '\n';
       std::string dstaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp->arp_data.arp_tip)));
-      //std::cout << "DEST IP: " << dstaddr << '\n';
+      std::cout << "DEST IP: " << dstaddr << '\n';
+      std::string localaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(ip_add_bin)));
+      std::cout << "LOCAL IP: " << localaddr << '\n';
+      
+      // Bail out if not out ipaddress
+      if ( arp->arp_data.arp_tip != ip_add_bin) return;
+
+      printf("ARP Received %i, local %i - I'm the target\n", ntohl(arp->arp_data.arp_tip), ntohl(ip_add_bin));
 
       /* Swap the two MAC addresses */
       ethAddrSwap(&arp->arp_data.arp_sha, &arp->arp_data.arp_tha);
@@ -149,7 +137,7 @@ pktgen_process_arp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t binary_ip_ad
       /* No need to free mbuf as it was reused */
       return;
     //} else {
-    //  printf("ARP Received %i, local %i - I'm not the target\n", ntohl(arp->arp_data.arp_tip), ntohl(binary_ip_address));
+    //  printf("ARP Received %i, local %i - I'm not the target\n", ntohl(arp->arp_data.arp_tip), ntohl(ip_add_bin));
     //}
   }
 }

--- a/src/arp/ARP.cpp
+++ b/src/arp/ARP.cpp
@@ -76,35 +76,28 @@ hex_digits_to_stream(std::ostringstream& ostrs, int value, char separator = ':',
 void
 pktgen_process_arp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t ip_add_bin)
 {
-  /*port_info_t   *info = &pktgen.info[port_id];*/
-  /*pkt_seq_t     *pkt;*/
   struct rte_ether_hdr *eth = rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
   struct rte_arp_hdr *arp = (struct rte_arp_hdr *)&eth[1];
 
-  /* Process all ARP requests if they are for us. */
-  //std::cout << "ARP code: " << (unsigned)arp->arp_opcode << '\n';
-
   if (arp->arp_opcode == rte_cpu_to_be_16(RTE_ARP_OP_REQUEST)) {
     arp->arp_opcode = rte_cpu_to_be_16(RTE_ARP_OP_REPLY);
-  //}
 
-  //if (arp->arp_opcode == htons(ARP_REQUEST) ) {
 
     /* Grab the source MAC addresses */
     struct rte_ether_addr mac_addr;
     rte_eth_macaddr_get(port_id, &mac_addr);
 
-      std::string srcaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp->arp_data.arp_sip)));
-      std::cout << "SRC IP: " << srcaddr << '\n';
-      std::string dstaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp->arp_data.arp_tip)));
-      std::cout << "DEST IP: " << dstaddr << '\n';
+      std::string srcaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp_hdr->arp_data.arp_sip)));
+      TLOG_DEBUG(10) << "SRC IP: " << srcaddr;
+      std::string dstaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp_hdr->arp_data.arp_tip)));
+      TLOG_DEBUG(10) << "DEST IP: " << dstaddr;
       std::string localaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(ip_add_bin)));
-      std::cout << "LOCAL IP: " << localaddr << '\n';
+      TLOG_DEBUG(10) << "LOCAL IP: " << localaddr;
       
-      // Bail out if not out ipaddress
+      // Bail out if not our ipaddress
       if ( arp->arp_data.arp_tip != ip_add_bin) return;
 
-      printf("ARP Received %i, local %i - I'm the target\n", ntohl(arp->arp_data.arp_tip), ntohl(ip_add_bin));
+      TLOG_DEBUG(10) << "ARP Received " << dstaddr << " I'm the target " << localaddr;
 
       /* Swap the two MAC addresses */
       ethAddrSwap(&arp->arp_data.arp_sha, &arp->arp_data.arp_tha);
@@ -117,28 +110,19 @@ pktgen_process_arp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t ip_add_bin)
 
       /* Swap the MAC addresses */
       ethAddrSwap(&eth->dst_addr, &eth->src_addr);
-      //ethAddrSwap(&eth->dst_addr, &eth->src_addr);
 
       /* Copy in the MAC address for the reply. */
       rte_memcpy(&arp->arp_data.arp_sha, &mac_addr, 6);
-      // rte_memcpy(&eth->src_addr, &mac_addr, 6);
       rte_memcpy(&eth->src_addr, &mac_addr, 6);
-
-      //pktgen_send_mbuf(m, port_id, 0);
 
       struct rte_mbuf *arp_tx_mbuf[1];
       arp_tx_mbuf[0] = m;
 
       rte_eth_tx_burst(port_id, 0, arp_tx_mbuf, 1);
-      printf("Sending ARP reply\n");
-      /* Flush all of the packets in the queue. */
-      //pktgen_set_q_flags(info, 0, DO_TX_FLUSH);
+      TLOG_DEBUG(10)  << "Sending ARP reply";
 
       /* No need to free mbuf as it was reused */
       return;
-    //} else {
-    //  printf("ARP Received %i, local %i - I'm not the target\n", ntohl(arp->arp_data.arp_tip), ntohl(ip_add_bin));
-    //}
   }
 }
 

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -152,29 +152,26 @@ IfaceWrapper::arp_response_runner(void *arg __rte_unused) {
         if (not RTE_ETH_IS_IPV4_HDR(pkt_type)) {
           //TLOG_DEBUG(10) << "Non-Ethernet packet type: " << (unsigned)pkt_type << " original: " << pkt_type;
           if (pkt_type == RTE_PTYPE_L2_ETHER_ARP) {
-            TLOG() << "TODO: Handle ARP request with IP allow-list!!!!";
+            TLOG_DEBUG(10) << "Handling ARP request";
             struct rte_ether_hdr* eth_hdr = rte_pktmbuf_mtod(m_arp_bufs[arp_rx_queue][i_b], struct rte_ether_hdr *);
             struct rte_arp_hdr* arp_hdr = (struct rte_arp_hdr *)(eth_hdr + 1);
 
             std::string srcaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp_hdr->arp_data.arp_sip)));
-            std::cout << "SRC IP: " << srcaddr << '\n';
+            TLOG_DEBUG(10) << "SRC IP: " << srcaddr;
             std::string dstaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp_hdr->arp_data.arp_tip)));
-            std::cout << "DEST IP: " << dstaddr << '\n';
+            TLOG_DEBUG(10) << "DEST IP: " << dstaddr;
 
             for( const auto& ip_addr_bin : m_ip_addr_bin) {
               std::string localaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(ip_addr_bin)));
-              std::cout << "LOCAL IP: " << localaddr << '\n';
+              TLOG_DEBUG(10) << "LOCAL IP: " << localaddr;
             }
 
 
             if (std::find(m_ip_addr_bin.begin(), m_ip_addr_bin.end(), arp_hdr->arp_data.arp_tip) != m_ip_addr_bin.end()) {
               arp::pktgen_process_arp(m_arp_bufs[arp_rx_queue][i_b], 0, arp_hdr->arp_data.arp_tip);
             } else {
-              TLOG() << "I'm not the ARP target";
+              TLOG_DEBUG(10) << "I'm not the ARP target";
             }
-            // if (ip is in as const auto& ip_addr_bin : m_ip_addr_bin ) {
-            //   arp::pktgen_process_arp(m_arp_bufs[arp_rx_queue][i_b], 0, ip_addr_bin);
-            //
           } else if (pkt_type == RTE_PTYPE_L2_ETHER_LLDP) {
             //TLOG_DEBUG(10) << "TODO: Handle LLDP packet!";
           } else {

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -156,8 +156,21 @@ IfaceWrapper::arp_response_runner(void *arg __rte_unused) {
             struct rte_ether_hdr* eth_hdr = rte_pktmbuf_mtod(m_arp_bufs[arp_rx_queue][i_b], struct rte_ether_hdr *);
             struct rte_arp_hdr* arp_hdr = (struct rte_arp_hdr *)(eth_hdr + 1);
 
+            std::string srcaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp_hdr->arp_data.arp_sip)));
+            std::cout << "SRC IP: " << srcaddr << '\n';
+            std::string dstaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp_hdr->arp_data.arp_tip)));
+            std::cout << "DEST IP: " << dstaddr << '\n';
+
+            for( const auto& ip_addr_bin : m_ip_addr_bin) {
+              std::string localaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(ip_addr_bin)));
+              std::cout << "LOCAL IP: " << localaddr << '\n';
+            }
+
+
             if (std::find(m_ip_addr_bin.begin(), m_ip_addr_bin.end(), arp_hdr->arp_data.arp_tip) != m_ip_addr_bin.end()) {
               arp::pktgen_process_arp(m_arp_bufs[arp_rx_queue][i_b], 0, arp_hdr->arp_data.arp_tip);
+            } else {
+              TLOG() << "I'm not the ARP target";
             }
             // if (ip is in as const auto& ip_addr_bin : m_ip_addr_bin ) {
             //   arp::pktgen_process_arp(m_arp_bufs[arp_rx_queue][i_b], 0, ip_addr_bin);

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -8,7 +8,7 @@ int
 IfaceWrapper::rx_runner(void *arg __rte_unused) {
 
   // Timespec for opportunistic sleep. Nanoseconds configured in conf.
-  struct timespec sleep_request = { 0, (long)m_lcore_sleep_ns };
+	struct timespec sleep_request = { 0, (long)m_lcore_sleep_ns };
 
   bool once = true; // One shot action variable.
   uint16_t iface = m_iface_id;
@@ -53,10 +53,9 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
 	      // Iterate on burst packets
         for (int i_b=0; i_b<nb_rx; ++i_b) {
 
-// RS FIXME: Removed for performance improvement hope
 /*
           // Check if packet is segmented. Implement support for it if needed.
-          if (q_bufs[i_b]->nb_segs > 1) {
+          if (q_bufs[i_b]->nb_segs > 1) [[unlikely]] {
 	          //TLOG_DEBUG(10) << "It appears a packet is spread across more than one receiving buffer;" 
             //               << " there's currently no logic in this program to handle this";
 	        }
@@ -64,10 +63,10 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
           // Check packet type, ommit/drop unexpected ones.
           auto pkt_type = q_bufs[i_b]->packet_type;
           //// Handle non IPV4 packets
-          if (not RTE_ETH_IS_IPV4_HDR(pkt_type)) {
+          if (not RTE_ETH_IS_IPV4_HDR(pkt_type)) [[unlikely]] {
             //TLOG_DEBUG(10) << "Non-Ethernet packet type: " << (unsigned)pkt_type << " original: " << pkt_type;
             if (pkt_type == RTE_PTYPE_L2_ETHER_ARP) {
-              //TLOG_DEBUG(10) << "TODO: Handle ARP request!";
+              //TLOG() << "Unexpected: Should handle an ARP request from lcore=" << lid << " rx_q=" << src_rx_q << "! Flow should be steered to dedicated RX Queue.";
             } else if (pkt_type == RTE_PTYPE_L2_ETHER_LLDP) {
               //TLOG_DEBUG(10) << "TODO: Handle LLDP packet!";
             } else {
@@ -119,6 +118,68 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
   } // main while(quit) loop
  
   TLOG() << "LCore RX runner on CPU[" << lid << "] returned.";
+  return 0;
+}
+
+
+int 
+IfaceWrapper::arp_response_runner(void *arg __rte_unused) {
+
+  // Timespec for opportunistic sleep. Nanoseconds configured in conf.
+  struct timespec sleep_request = { 0, (long)900000 };
+
+  bool once = true; // One shot action variable.
+  uint16_t iface = m_iface_id;
+
+  const uint16_t lid = rte_lcore_id();
+  unsigned arp_rx_queue = m_arp_rx_queue;
+
+  TLOG() << "LCore ARP responder on CPU[" << lid << "]: Main loop starts for iface " << iface << " rx queue: " << arp_rx_queue;
+
+  // While loop of quit atomic member in IfaceWrapper
+  while(!this->m_lcore_quit_signal.load()) {
+
+    const uint16_t nb_rx = rte_eth_rx_burst(iface, arp_rx_queue, m_arp_bufs[arp_rx_queue], m_burst_size);
+
+    // We got packets from burst on this queue
+    if (nb_rx != 0) {
+      // Iterate on burst packets
+      for (int i_b=0; i_b<nb_rx; ++i_b) {
+
+        // Check packet type, ommit/drop unexpected ones.
+        auto pkt_type = m_arp_bufs[arp_rx_queue][i_b]->packet_type;
+        //// Handle non IPV4 packets
+        if (not RTE_ETH_IS_IPV4_HDR(pkt_type)) {
+          //TLOG_DEBUG(10) << "Non-Ethernet packet type: " << (unsigned)pkt_type << " original: " << pkt_type;
+          if (pkt_type == RTE_PTYPE_L2_ETHER_ARP) {
+            TLOG() << "TODO: Handle ARP request with IP allow-list!!!!";
+            // if (ip is in as const auto& ip_addr_bin : m_ip_addr_bin ) {
+            //   arp::pktgen_process_arp(m_arp_bufs[arp_rx_queue][i_b], 0, ip_addr_bin);
+            //
+          } else if (pkt_type == RTE_PTYPE_L2_ETHER_LLDP) {
+            //TLOG_DEBUG(10) << "TODO: Handle LLDP packet!";
+          } else {
+            //TLOG_DEBUG(10) << "Unidentified! Dumping...";
+            //rte_pktmbuf_dump(stdout, m_arp_bufs[arp_rx_queue][i_b], m_bufs[src_rx_q][i_b]->pkt_len);
+          }
+          continue;
+        }
+      }
+
+      // Bulk free of mbufs
+      rte_pktmbuf_free_bulk(m_arp_bufs[arp_rx_queue], nb_rx);
+      
+    } // per burst
+
+    // If no full buffers in burst...
+    if (m_lcore_sleep_ns) {
+      // Sleep n nanoseconds... (value from config, timespec initialized in lcore first lines)
+      /*int response =*/ nanosleep(&sleep_request, nullptr);
+    }
+
+  } // main while(quit) loop
+ 
+  TLOG() << "LCore ARP responder on CPU[" << lid << "] returned.";
   return 0;
 }
 

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -1,5 +1,5 @@
-
 #include <time.h>
+#include <rte_arp.h>
 
 namespace dunedaq {
 namespace dpdklibs {
@@ -153,6 +153,12 @@ IfaceWrapper::arp_response_runner(void *arg __rte_unused) {
           //TLOG_DEBUG(10) << "Non-Ethernet packet type: " << (unsigned)pkt_type << " original: " << pkt_type;
           if (pkt_type == RTE_PTYPE_L2_ETHER_ARP) {
             TLOG() << "TODO: Handle ARP request with IP allow-list!!!!";
+            struct rte_ether_hdr* eth_hdr = rte_pktmbuf_mtod(m_arp_bufs[arp_rx_queue][i_b], struct rte_ether_hdr *);
+            struct rte_arp_hdr* arp_hdr = (struct rte_arp_hdr *)(eth_hdr + 1);
+
+            if (std::find(m_ip_addr_bin.begin(), m_ip_addr_bin.end(), arp_hdr->arp_data.arp_tip) != m_ip_addr_bin.end()) {
+              arp::pktgen_process_arp(m_arp_bufs[arp_rx_queue][i_b], 0, arp_hdr->arp_data.arp_tip);
+            }
             // if (ip is in as const auto& ip_addr_bin : m_ip_addr_bin ) {
             //   arp::pktgen_process_arp(m_arp_bufs[arp_rx_queue][i_b], 0, ip_addr_bin);
             //

--- a/test/apps/test_arp_response.cxx
+++ b/test/apps/test_arp_response.cxx
@@ -14,6 +14,7 @@
 #include <rte_ethdev.h>
 #include <rte_lcore.h>
 #include <rte_mbuf.h>
+#include <rte_arp.h>
 
 #include <sstream>
 #include <stdint.h>
@@ -38,6 +39,45 @@ namespace {
 
 } // namespace ""
 
+void print_arp(struct rte_mbuf *mbuf) {
+  struct rte_ether_hdr *eth_hdr;
+  struct rte_arp_hdr *arp_hdr;
+
+  // Get Ethernet header
+  eth_hdr = rte_pktmbuf_mtod(mbuf, struct rte_ether_hdr *);
+
+  // Check for ARP packet
+  if (eth_hdr->ether_type == rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP)) {
+      // ARP header is directly after Ethernet header
+      arp_hdr = (struct rte_arp_hdr *)(eth_hdr + 1);
+
+      // Convert IPs from network to host byte order
+      uint32_t sender_ip = rte_be_to_cpu_32(arp_hdr->arp_data.arp_sip);
+      uint32_t target_ip = rte_be_to_cpu_32(arp_hdr->arp_data.arp_tip);
+
+      printf("ARP Sender MAC: %02X:%02X:%02X:%02X:%02X:%02X\n",
+             arp_hdr->arp_data.arp_sha.addr_bytes[0],
+             arp_hdr->arp_data.arp_sha.addr_bytes[1],
+             arp_hdr->arp_data.arp_sha.addr_bytes[2],
+             arp_hdr->arp_data.arp_sha.addr_bytes[3],
+             arp_hdr->arp_data.arp_sha.addr_bytes[4],
+             arp_hdr->arp_data.arp_sha.addr_bytes[5]);
+
+      printf("ARP Sender IP: %u.%u.%u.%u\n",
+             (sender_ip >> 24) & 0xFF,
+             (sender_ip >> 16) & 0xFF,
+             (sender_ip >> 8) & 0xFF,
+             sender_ip & 0xFF);
+
+      printf("ARP Target IP: %u.%u.%u.%u\n",
+             (target_ip >> 24) & 0xFF,
+             (target_ip >> 16) & 0xFF,
+             (target_ip >> 8) & 0xFF,
+             target_ip & 0xFF);
+  }
+}
+
+
 static int
 lcore_main(struct rte_mempool *mbuf_pool)
 {
@@ -45,14 +85,14 @@ lcore_main(struct rte_mempool *mbuf_pool)
   TLOG() << "Launch lcore for interface: " << iface;
 
   // IP for ARP
-  std::string ip_addr_str{"10.73.32.192"};
+  std::string ip_addr_str{"10.73.32.129"};
   TLOG() << "IP address for ARP responses: " << ip_addr_str;
   IpAddr ip_addr(ip_addr_str);
   rte_be32_t ip_addr_bin = ip_address_dotdecimal_to_binary(
-    ip_addr.addr_bytes[3],
-    ip_addr.addr_bytes[2],
+    ip_addr.addr_bytes[0],
     ip_addr.addr_bytes[1],
-    ip_addr.addr_bytes[0]
+    ip_addr.addr_bytes[2],
+    ip_addr.addr_bytes[3]
   );
 
   struct rte_mbuf **tx_bufs = (rte_mbuf**) malloc(sizeof(struct rte_mbuf*) * burst_size);
@@ -95,15 +135,16 @@ lcore_main(struct rte_mempool *mbuf_pool)
         if (not RTE_ETH_IS_IPV4_HDR(pkt_type)) {
           TLOG() << "Non-Ethernet packet type: " << (unsigned)pkt_type;
           if (pkt_type == RTE_PTYPE_L2_ETHER_ARP) {
-            TLOG() << "TODO: Handle ARP request!";
+            TLOG() << "ARP request detected!";
             rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
+            print_arp(bufs[i_b]);
             arp::pktgen_process_arp(bufs[i_b], 0, ip_addr_bin);
           } else if (pkt_type == RTE_PTYPE_L2_ETHER_LLDP) {
             TLOG() << "TODO: Handle LLDP packet!";
             //rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
           } else {
             TLOG() << "Unidentified! Dumping...";
-            //rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
+            rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
           }
           continue;
         }

--- a/test/apps/test_arp_response.cxx
+++ b/test/apps/test_arp_response.cxx
@@ -23,6 +23,15 @@
 #include <fstream>
 #include <csignal>
 
+#include "CLI/App.hpp"
+#include "CLI/Config.hpp"
+#include "CLI/Formatter.hpp"
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+#include <regex>
+
 using namespace dunedaq;
 using namespace dpdklibs;
 using namespace udp;
@@ -79,13 +88,13 @@ void print_arp(struct rte_mbuf *mbuf) {
 
 
 static int
-lcore_main(struct rte_mempool *mbuf_pool)
+lcore_main(struct rte_mempool *mbuf_pool, std::string ip_addr_str)
 {
   uint16_t iface = 0;
   TLOG() << "Launch lcore for interface: " << iface;
 
   // IP for ARP
-  std::string ip_addr_str{"10.73.32.129"};
+  // std::string ip_addr_str{"10.73.32.129"};
   TLOG() << "IP address for ARP responses: " << ip_addr_str;
   IpAddr ip_addr(ip_addr_str);
   rte_be32_t ip_addr_bin = ip_address_dotdecimal_to_binary(
@@ -160,13 +169,70 @@ lcore_main(struct rte_mempool *mbuf_pool)
 int
 main(int argc, char* argv[])
 {  
-  int ret = rte_eal_init(argc, argv);
-  if (ret < 0) {
-    rte_exit(EXIT_FAILURE, "ERROR: EAL initialization failed.\n");
+
+  uint16_t iface_id = 0;
+  std::string ip_address;
+  std::vector<std::string> pcie_addresses;
+
+  CLI::App app{"test arp responses"};
+  app.add_option("-a,--ip-address", ip_address, "IP Addresses");
+  app.add_option("-m,--pcie-mask", pcie_addresses, "PCIE Addresses device mask");
+  app.add_option("-i,--iface", iface_id, "Interface to init");
+
+  CLI11_PARSE(app, argc, argv);
+
+  // Validate arguments
+  fmt::print("ip      : {}\n", ip_address);
+  fmt::print("pcies   : {}\n", fmt::join(pcie_addresses," | "));
+
+  std::regex re_ipv4("[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}");
+  std::regex re_pcie("^0{0,4}:[a-fA-F0-9]{2}:[a-fA-F0-9]{2}.[0-9]$");
+
+  // bool all_ip_ok = true;
+  // for( const auto& ip: garp_ip_addresses) {
+  //     bool ip_ok = std::regex_match(ip, re_ipv4);
+  //     fmt::print("- {} {}\n", ip, ip_ok);
+  //     all_ip_ok &= ip_ok;
+  // }
+
+  bool ip_ok = std::regex_match(ip_address, re_ipv4);
+  fmt::print("IP address {} {}\n", ip_address, ip_ok);
+
+
+  fmt::print("PCIE addresses\n");
+  bool all_pcie_ok = true;
+  for( const auto& pcie: pcie_addresses) {
+      bool pcie_ok = std::regex_match(pcie, re_pcie);
+      fmt::print("- {} {}\n", pcie, pcie_ok);
+      all_pcie_ok &= pcie_ok;
   }
 
+  if (!ip_ok or !all_pcie_ok) {
+      return -1;
+  }
+
+  std::vector<std::string> eal_args;
+  eal_args.push_back("dpdklibds_test_garp");
+  for( const auto& pcie: pcie_addresses) {
+      eal_args.push_back("-a");
+      eal_args.push_back(pcie);
+  }
+  dunedaq::dpdklibs::ealutils::init_eal(eal_args);
+
+  auto n_ifaces = rte_eth_dev_count_avail();
+  fmt::print("# of available ifaces: {}\n", n_ifaces);
+  if (n_ifaces == 0){
+      std::cout << "WARNING: no available ifaces. exiting...\n";
+      rte_eal_cleanup();
+      return 1;
+  }
+
+  // int ret = rte_eal_init(argc, argv);
+  // if (ret < 0) {
+  //   rte_exit(EXIT_FAILURE, "ERROR: EAL initialization failed.\n");
+  // }
+
   // Iface ID and its queue numbers
-  int iface_id = 0;
   const uint16_t rx_qs = 1;
   const uint16_t tx_qs = 1;
   const uint16_t rx_ring_size = 1024;
@@ -204,7 +270,7 @@ main(int argc, char* argv[])
   }
 
   // Launch lcores
-  lcore_main(mbuf_pools[0].get());
+  lcore_main(mbuf_pools[0].get(), ip_address);
 
   // Cleanup
   TLOG() << "EAL cleanup...";

--- a/test/apps/test_arp_response.cxx
+++ b/test/apps/test_arp_response.cxx
@@ -6,6 +6,7 @@
 #include "dpdklibs/udp/Utils.hpp"
 #include "dpdklibs/arp/ARP.hpp"
 #include "dpdklibs/ipv4_addr.hpp"
+#include "dpdklibs/FlowControl.hpp"
 
 #include <inttypes.h>
 #include <rte_cycles.h>
@@ -44,7 +45,7 @@ lcore_main(struct rte_mempool *mbuf_pool)
   TLOG() << "Launch lcore for interface: " << iface;
 
   // IP for ARP
-  std::string ip_addr_str{"10.73.139.26"};
+  std::string ip_addr_str{"10.73.32.192"};
   TLOG() << "IP address for ARP responses: " << ip_addr_str;
   IpAddr ip_addr(ip_addr_str);
   rte_be32_t ip_addr_bin = ip_address_dotdecimal_to_binary(
@@ -63,8 +64,8 @@ lcore_main(struct rte_mempool *mbuf_pool)
       num_packets.exchange(0);
       num_bytes.exchange(0);
 
-      arp::pktgen_send_garp(tx_bufs[0], iface, ip_addr_bin);
-      ++garps_sent;
+      //arp::pktgen_send_garp(tx_bufs[0], iface, ip_addr_bin);
+      //++garps_sent;
 
       std::this_thread::sleep_for(std::chrono::seconds(1)); // If we sample for anything other than 1s, the rate calculation will need to change
     }
@@ -96,13 +97,13 @@ lcore_main(struct rte_mempool *mbuf_pool)
           if (pkt_type == RTE_PTYPE_L2_ETHER_ARP) {
             TLOG() << "TODO: Handle ARP request!";
             rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
-            //arp::pktgen_process_arp(bufs[i_b], 0, ip_addr_bin);
+            arp::pktgen_process_arp(bufs[i_b], 0, ip_addr_bin);
           } else if (pkt_type == RTE_PTYPE_L2_ETHER_LLDP) {
             TLOG() << "TODO: Handle LLDP packet!";
-            rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
+            //rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
           } else {
             TLOG() << "Unidentified! Dumping...";
-            rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
+            //rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
           }
           continue;
         }
@@ -144,6 +145,22 @@ main(int argc, char* argv[])
   TLOG() << "Initialize interface " << iface_id;
   ealutils::iface_init(iface_id, rx_qs, tx_qs, rx_ring_size, tx_ring_size, mbuf_pools);
   ealutils::iface_promiscuous_mode(iface_id, true); // should come from config
+
+  // Flow steering setup
+  TLOG() << "Configuring Flow steering rules for iface=" << iface_id;
+  struct rte_flow_error error;
+  struct rte_flow *flow;
+  TLOG() << "Attempt to flush previous flow rules...";
+  rte_flow_flush(iface_id, &error);
+  TLOG() << "Create control flow rules (ARP).";
+
+  flow = generate_arp_flow(iface_id, 0, &error);
+  if (not flow) { // ers::fatal
+    TLOG() << "Flow can't be created for ARP queue=0"
+           << " Error type: " << (unsigned)error.type
+           << " Message: " << error.message;
+    return 1;
+  }
 
   // Launch lcores
   lcore_main(mbuf_pools[0].get());


### PR DESCRIPTION
TDE electronics uses ARP messages to resolve the hardware address of the receiver endpoint of the data packets, based on its assumed ip address. The `dpdklibs::DPDKReaderModule` ARP response implementation never worked correctly and needed to be fixed.
Debugged and re-enabled ARP support with dedicated. 
Added extra core assignment checks to avoid silent failures when spawning rte workers.

Part of DUNE-DAQ/daq-deliverables#166