### PR TITLE
GARP packets endianness

### DIFF
--- a/src/arp/ARP.cpp
+++ b/src/arp/ARP.cpp
@@ -65,7 +65,6 @@ pktgen_send_garp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t ip_add_bin)
   TLOG_DEBUG(10) << "LOCAL IP: " << localaddr;
 
   rte_eth_tx_burst(port_id, 0, arp_tx_mbuf, 1);
-  printf("Sending GARP\n");
 }
 
 
@@ -93,14 +92,14 @@ pktgen_process_arp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t ip_add_bin)
       std::string dstaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp->arp_data.arp_tip)));
       std::string localaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(ip_add_bin)));
       
-      TLOG() << "ARP SRC IP: " << srcaddr;
-      TLOG() << "ARP DEST IP: " << dstaddr;
-      TLOG() << "ARP LOCAL IP: " << localaddr;
-      
+      TLOG_DEBUG(10) << "ARP SRC IP: " << srcaddr;
+      TLOG_DEBUG(10) << "ARP DEST IP: " << dstaddr;
+      TLOG_DEBUG(10) << "ARP LOCAL IP: " << localaddr;
+
       // Bail out if not our ipaddress
       if ( arp->arp_data.arp_tip != ip_add_bin) return;
 
-      TLOG() << "ARP Received " << dstaddr << " I'm the target " << localaddr;
+      TLOG_DEBUG(10) << "ARP Received " << dstaddr << " I'm the target " << localaddr;
 
       /* Swap the two MAC addresses */
       ethAddrSwap(&arp->arp_data.arp_sha, &arp->arp_data.arp_tha);

--- a/src/arp/ARP.cpp
+++ b/src/arp/ARP.cpp
@@ -38,17 +38,10 @@ pktgen_send_garp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t ip_add_bin)
   memset(arp, 0, sizeof(struct rte_arp_hdr));
   rte_memcpy(&arp->arp_data.arp_sha, &mac_addr, 6);
   
-  uint32_t addr = htonl(ip_add_bin);
-  inetAddrCopy(&arp->arp_data.arp_sip, &addr);
+  inetAddrCopy(&arp->arp_data.arp_sip, &ip_add_bin);
 
-  //if (likely(type == GRATUITOUS_ARP) ) {
-		rte_memcpy(&arp->arp_data.arp_tha, &mac_addr, 6);
-		inetAddrCopy(&arp->arp_data.arp_tip, &addr);
-  //} else {
-  //  memset(&arp->arp_data.arp_tha, 0, 6);
-  //  addr = htonl(pkt->ip_dst_addr.addr.ipv4.s_addr);
-  //  inetAddrCopy(&arp->arp_data.arp_tip, &addr);
-  //}
+  rte_memcpy(&arp->arp_data.arp_tha, &mac_addr, 6);
+  inetAddrCopy(&arp->arp_data.arp_tip, &ip_add_bin);
 
   /* Fill in the rest of the ARP packet header */
 	arp->arp_hardware = htons(RTE_ARP_HRD_ETHER);
@@ -62,8 +55,17 @@ pktgen_send_garp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t ip_add_bin)
 
   struct rte_mbuf *arp_tx_mbuf[1];
   arp_tx_mbuf[0] = m;
+
+
+  std::string srcaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp->arp_data.arp_sip)));
+  std::string dstaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp->arp_data.arp_tip)));
+  std::string localaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(ip_add_bin)));
+  TLOG_DEBUG(10) << "GARP SRC IP: " << srcaddr;
+  TLOG_DEBUG(10) << "GARP DEST IP: " << dstaddr;
+  TLOG_DEBUG(10) << "LOCAL IP: " << localaddr;
+
   rte_eth_tx_burst(port_id, 0, arp_tx_mbuf, 1);
-  //printf("Sending ARP reply\n");
+  printf("Sending GARP\n");
 }
 
 
@@ -88,16 +90,17 @@ pktgen_process_arp(struct rte_mbuf *m, uint32_t port_id, rte_be32_t ip_add_bin)
     rte_eth_macaddr_get(port_id, &mac_addr);
 
       std::string srcaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp->arp_data.arp_sip)));
-      TLOG_DEBUG(10) << "SRC IP: " << srcaddr;
       std::string dstaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(arp->arp_data.arp_tip)));
-      TLOG_DEBUG(10) << "DEST IP: " << dstaddr;
       std::string localaddr = dunedaq::dpdklibs::udp::get_ipv4_decimal_addr_str(dunedaq::dpdklibs::udp::ip_address_binary_to_dotdecimal(rte_be_to_cpu_32(ip_add_bin)));
-      TLOG_DEBUG(10) << "LOCAL IP: " << localaddr;
+      
+      TLOG() << "ARP SRC IP: " << srcaddr;
+      TLOG() << "ARP DEST IP: " << dstaddr;
+      TLOG() << "ARP LOCAL IP: " << localaddr;
       
       // Bail out if not our ipaddress
       if ( arp->arp_data.arp_tip != ip_add_bin) return;
 
-      TLOG_DEBUG(10) << "ARP Received " << dstaddr << " I'm the target " << localaddr;
+      TLOG() << "ARP Received " << dstaddr << " I'm the target " << localaddr;
 
       /* Swap the two MAC addresses */
       ethAddrSwap(&arp->arp_data.arp_sha, &arp->arp_data.arp_tha);

--- a/test/apps/test_arp_response.cxx
+++ b/test/apps/test_arp_response.cxx
@@ -145,8 +145,13 @@ lcore_main(struct rte_mempool *mbuf_pool, std::string ip_addr_str)
           TLOG() << "Non-Ethernet packet type: " << (unsigned)pkt_type;
           if (pkt_type == RTE_PTYPE_L2_ETHER_ARP) {
             TLOG() << "ARP request detected!";
+            
             rte_pktmbuf_dump(stdout, bufs[i_b], bufs[i_b]->pkt_len);
-            print_arp(bufs[i_b]);
+            // print_arp(bufs[i_b]);
+
+
+
+
             arp::pktgen_process_arp(bufs[i_b], 0, ip_addr_bin);
           } else if (pkt_type == RTE_PTYPE_L2_ETHER_LLDP) {
             TLOG() << "TODO: Handle LLDP packet!";

--- a/test/apps/test_frame_receiver.cxx
+++ b/test/apps/test_frame_receiver.cxx
@@ -280,10 +280,10 @@ static int lcore_main(struct rte_mempool* mbuf_pool, uint16_t iface, uint64_t ti
     TLOG() << "IP address for ARP responses: " << ip_addr_str;
         IpAddr ip_addr(ip_addr_str);
         rte_be32_t ip_addr_bin = ip_address_dotdecimal_to_binary(
-        ip_addr.addr_bytes[3],
-        ip_addr.addr_bytes[2],
-        ip_addr.addr_bytes[1],
-        ip_addr.addr_bytes[0]
+            ip_addr.addr_bytes[0],
+            ip_addr.addr_bytes[1],
+            ip_addr.addr_bytes[2],
+            ip_addr.addr_bytes[3]
         );
         ip_addr_bin_vector.push_back(ip_addr_bin);
     }


### PR DESCRIPTION
GARP packets are being sent with IP addresses in little endian format, due to an extra byte swap.
This PR removes the swap.
It also fixes another byte swap in the encoding of garp addresses in `test_frame_receiver`