### PR TITLE
Payload handling and state monitoring improvements

### DIFF
--- a/src/EALSetup.cpp
+++ b/src/EALSetup.cpp
@@ -158,6 +158,13 @@ iface_init(uint16_t iface, uint16_t rx_rings, uint16_t tx_rings,
     TLOG() << "Interface: " << iface << " MTU: " << mtu;
   }
 
+  // Set PTYPE parsing. RS FIXME: This function needs to be factorized, with overall better offloading control.
+  // On most Intel and Mellanox drivers, packet_type will automatically be set if:
+  //   - the hardware supports RTE_ETH_RX_OFFLOAD_*PTYPE
+  //   - and ptype RX parsing is enabled in the PMD
+  // Some PMDs require calling:
+  rte_eth_dev_set_ptypes(iface, RTE_PTYPE_L2_MASK | RTE_PTYPE_L3_MASK | RTE_PTYPE_L4_MASK, NULL, 0);
+
   // // Adjust RX/TX ring sizes
   // retval = rte_eth_dev_adjust_nb_rx_tx_desc(iface, &nb_rxd, &nb_txd);
   // if (retval != 0)

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -298,11 +298,19 @@ IfaceWrapper::setup_xstats()
 void
 IfaceWrapper::start()
 {
+  // Reset counters for RX queues
   for (auto const& [rx_q, _] : m_num_frames_rxq ) {
     m_num_frames_rxq[rx_q] = { 0 };
     m_num_bytes_rxq[rx_q] = { 0 };
     m_num_full_bursts[rx_q] = { 0 };
     m_max_burst_size[rx_q] = { 0 };
+  }
+
+  // Reset counters for rte_workers
+  for (auto const& [lcore, _] : m_rx_core_map) {
+    m_num_unhandled_non_ipv4[lcore] = { 0 };
+    m_num_unhandled_non_udp[lcore] = { 0 };
+    m_num_unhandled_non_jumbo_udp[lcore] = { 0 };
   }
 
   m_lcore_enable_flow.store(false);

--- a/src/IfaceWrapper.hpp
+++ b/src/IfaceWrapper.hpp
@@ -122,9 +122,17 @@ private:
   // Stats by queues
   std::map<int, std::atomic<std::size_t>> m_num_frames_rxq;
   std::map<int, std::atomic<std::size_t>> m_num_bytes_rxq;
-  std::map<int, std::atomic<std::size_t>> m_num_unexid_frames;
   std::map<int, std::atomic<std::size_t>> m_num_full_bursts;
   std::map<int, std::atomic<uint16_t>> m_max_burst_size;
+
+  // Stats by rte_workers
+  std::map<int, std::atomic<std::size_t>> m_num_unhandled_non_ipv4;
+  std::map<int, std::atomic<std::size_t>> m_num_unhandled_non_udp;
+  std::map<int, std::atomic<std::size_t>> m_num_unhandled_non_jumbo_udp;
+
+  // Unexpected stream ID count
+  std::map<int, std::atomic<std::size_t>> m_num_unexid_frames;
+
 
   // DPDK HW stats
   dpdklibs::IfaceXstats m_iface_xstats;

--- a/src/SourceConcept.hpp
+++ b/src/SourceConcept.hpp
@@ -43,6 +43,7 @@ namespace dunedaq {
       //  virtual void start(const nlohmann::json& args) = 0;
       //  virtual void stop(const nlohmann::json& args) = 0;
 
+      // Meant to process an incoming raw byte buffer and extract complete payloads of arbitrary types in specialized models.
       virtual bool handle_payload(char* message, std::size_t size) = 0;
 
       void set_sink_name(const std::string& sink_name) 

--- a/src/SourceConcept.hpp
+++ b/src/SourceConcept.hpp
@@ -44,7 +44,7 @@ namespace dunedaq {
       //  virtual void stop(const nlohmann::json& args) = 0;
 
       // Meant to process an incoming raw byte buffer and extract complete payloads of arbitrary types in specialized models.
-      virtual bool handle_payload(char* message, std::size_t size) = 0;
+      virtual void handle_payload(char* message, std::size_t size) = 0;
 
       void set_sink_name(const std::string& sink_name) 
       { 

--- a/src/SourceModel.hpp
+++ b/src/SourceModel.hpp
@@ -93,16 +93,20 @@ public:
       ++m_leftover_bytes_encountered;
     }
     
-    // Handle full target payloads
+    // Process each full payload
     for (std::size_t i = 0; i < full_payloads; ++i) {
       // Calculate pointer to the i-th payload chunk inside the message buffer.
-      // This is a raw reinterpret_cast from char* to TargetPayloadType*,
-      // effectively creating a reference directly into the input buffer (zero-copy).
-      TargetPayloadType& payload = 
-        *reinterpret_cast<TargetPayloadType*>(message + i * m_expected_payload_size);
+      const char* src = message + i * m_expected_payload_size;
     
+      // Materialize a real TargetPayloadType object by copying bytes from the buffer.
+      // This is defined behavior, alignment-safe, and fast, without pointer vodoo
+      // Previously reinterpret_cast to TargetPayloadType* introduced alignment traps 
+      // “pretend there’s a constructed object there” UB. Scatter won't work like that.
+      TargetPayloadType payload;
+      std::memcpy(&payload, src, m_expected_payload_size);
+
       if (m_callback_mode) {
-        // Callback mode: directly pass the payload to a sink callback.
+        // Pass by value (moved); no references into 'message', so no UAF.
         (*m_sink_callback)(std::move(payload));
       } else {
         // Queue mode: attempt to enqueue the payload in a non-blocking way.
@@ -110,8 +114,7 @@ public:
            ++m_failed_to_send_daq_payloads;
         }
       }
-    } 
-    
+    }
   }
 
   void generate_opmon_data() override {
@@ -130,6 +133,7 @@ public:
 private:
   // Constants
   const std::size_t m_expected_payload_size = sizeof(TargetPayloadType);
+
 
   // Sink internals
   std::string m_sink_id;

--- a/src/SourceModel.hpp
+++ b/src/SourceModel.hpp
@@ -79,88 +79,58 @@ public:
     }
   }
 
+  // Exposes sink via returning a pointer to it. 
   std::shared_ptr<sink_t>& get_sink() { return m_sink_queue; }
 
   // Process an incoming raw byte buffer and extract complete payloads of type TargetPayloadType.
-  bool handle_payload(char* message, std::size_t size)
+  void handle_payload(char* message, std::size_t size)
   {
-      // Determine the exact size in bytes of one complete and payload.
-      const std::size_t payload_size = sizeof(TargetPayloadType);
-  
-      // Calculate how many full payloads fit in the incoming message buffer.
-      std::size_t full_payloads = size / payload_size;
-  
-      // Calculate leftover bytes that don't form a complete payload.
-      std::size_t leftover_bytes = size % payload_size;
-
-      // RS FIXME - 0cpy variant:
-      for (std::size_t i = 0; i < full_payloads; ++i) {
-        // Calculate pointer to the i-th payload chunk inside the message buffer.
-        // This is a raw reinterpret_cast from char* to TargetPayloadType*,
-        // effectively creating a reference directly into the input buffer (zero-copy).
-        TargetPayloadType& payload = 
-          *reinterpret_cast<TargetPayloadType*>(message + i * payload_size);
-
-        if (m_callback_mode) {
-          (*m_sink_callback)(std::move(payload));
-        } else {
-          if (!m_sink_queue->try_send(std::move(payload), iomanager::Sender::s_no_block)) {
-             ++m_dropped_packets;
-          }
+    // Calculate how many full payloads fit in the incoming message buffer.
+    std::size_t full_payloads = size / m_expected_payload_size;
+    
+    // Calculate leftover bytes that don't form a complete payload.
+    if (size % m_expected_payload_size > 0) [[unlikely]] {
+      ++m_leftover_bytes_encountered;
+    }
+    
+    // Handle full target payloads
+    for (std::size_t i = 0; i < full_payloads; ++i) {
+      // Calculate pointer to the i-th payload chunk inside the message buffer.
+      // This is a raw reinterpret_cast from char* to TargetPayloadType*,
+      // effectively creating a reference directly into the input buffer (zero-copy).
+      TargetPayloadType& payload = 
+        *reinterpret_cast<TargetPayloadType*>(message + i * m_expected_payload_size);
+    
+      if (m_callback_mode) {
+        // Callback mode: directly pass the payload to a sink callback.
+        (*m_sink_callback)(std::move(payload));
+      } else {
+        // Queue mode: attempt to enqueue the payload in a non-blocking way.
+        if (!m_sink_queue->try_send(std::move(payload), iomanager::Sender::s_no_block)) {
+           ++m_failed_to_send_daq_payloads;
         }
-      } 
-
-/*
-      // RS FIXME - MEMCPY variant:
-      // Iterate through each full payload in the buffer.
-      for (std::size_t i = 0; i < full_payloads; ++i) [[likely]] {{
-          // Create a local instance to hold the extracted payload.
-          TargetPayloadType payload;
-  
-          // Copy the raw bytes into our strongly typed payload object.
-          // This assumes payload is trivially copyable or POD-like. 
-          //   - RS FIXME: TBD to ensure or ommit type safety in the plugin's design 
-          // Note: Using std::memcpy avoids undefined behavior from strict aliasing.
-          std::memcpy(&payload, message + i * payload_size, payload_size);
-  
-          if (m_callback_mode) {
-              // Callback mode: directly pass the payload to a sink callback.
-              // Using std::move allows for efficient transfer if payload supports move semantics.
-              (*m_sink_callback)(std::move(payload));
-          } else {
-              // Queue mode: attempt to enqueue the payload in a non-blocking way.
-              if (!m_sink_queue->try_send(std::move(payload), iomanager::Sender::s_no_block)) {
-                  // Queue is full or unavailable: record a dropped packet.
-                  ++m_dropped_packets;  // total drop counter
-              }
-          }
       }
-*/  
-
-      // If we received bytes that don't form a complete payload...
-      if (leftover_bytes > 0) {
-          // RS FIXME: Record this as a bad DAQ stream payload for monitoring/statistics purposes.
-          //++m_bad_daq_stream_payload_count;
-      }
-  
-      // Function result: true only if:
-      // - No leftover bytes remained (i.e., input perfectly aligned to payload size)
-      return leftover_bytes == 0;
+    } 
+    
   }
 
   void generate_opmon_data() override {
       
-    if(m_dropped_packets != 0) {
-        ers::warning(FailedToSendData(ERS_HERE, m_sink_id, m_dropped_packets));
+    if(m_failed_to_send_daq_payloads != 0) {
+        ers::warning(FailedToSendData(ERS_HERE, m_sink_id, m_failed_to_send_daq_payloads));
     }
 
     opmon::SourceInfo info;
-    info.set_dropped_frames( m_dropped_packets.load() ); 
+    // RS FIXME: These are NOT dropped frames!!! Rename on opmon is needed
+    info.set_dropped_frames( m_failed_to_send_daq_payloads.exchange(0) ); 
 
     publish( std::move(info) );
   }
   
 private:
+  // Constants
+  const std::size_t m_expected_payload_size = sizeof(TargetPayloadType);
+
   // Sink internals
   std::string m_sink_id;
   bool m_sink_is_set{ false };
@@ -172,7 +142,9 @@ private:
   using sink_cb_t = std::shared_ptr<std::function<void(TargetPayloadType&&)>>;
   sink_cb_t m_sink_callback;
 
-  std::atomic<uint64_t> m_dropped_packets{0};
+  // Stats
+  std::atomic<uint64_t> m_leftover_bytes_encountered{0};
+  std::atomic<uint64_t> m_failed_to_send_daq_payloads{0};
 
 };
 

--- a/src/SourceModel.hpp
+++ b/src/SourceModel.hpp
@@ -81,28 +81,71 @@ public:
 
   std::shared_ptr<sink_t>& get_sink() { return m_sink_queue; }
 
-  bool handle_payload(char* message, std::size_t size) // NOLINT(build/unsigned)
+  // Process an incoming raw byte buffer and extract complete payloads of type TargetPayloadType.
+  bool handle_payload(char* message, std::size_t size)
   {
-    bool push_out = true;
-    if (push_out) {
-
-      TargetPayloadType& target_payload = *reinterpret_cast<TargetPayloadType*>(message);
+      // Determine the exact size in bytes of one complete and payload.
+      const std::size_t payload_size = sizeof(TargetPayloadType);
   
-      if (m_callback_mode) {
-        (*m_sink_callback)(std::move(target_payload));
-      } else {
-        if (!m_sink_queue->try_send(std::move(target_payload), iomanager::Sender::s_no_block)) {
-          ++m_dropped_packets;
+      // Calculate how many full payloads fit in the incoming message buffer.
+      std::size_t full_payloads = size / payload_size;
+  
+      // Calculate leftover bytes that don't form a complete payload.
+      std::size_t leftover_bytes = size % payload_size;
+
+      // RS FIXME - 0cpy variant:
+      for (std::size_t i = 0; i < full_payloads; ++i) {
+        // Calculate pointer to the i-th payload chunk inside the message buffer.
+        // This is a raw reinterpret_cast from char* to TargetPayloadType*,
+        // effectively creating a reference directly into the input buffer (zero-copy).
+        TargetPayloadType& payload = 
+          *reinterpret_cast<TargetPayloadType*>(message + i * payload_size);
+
+        if (m_callback_mode) {
+          (*m_sink_callback)(std::move(payload));
+        } else {
+          if (!m_sink_queue->try_send(std::move(payload), iomanager::Sender::s_no_block)) {
+             ++m_dropped_packets;
+          }
         }
+      } 
+
+/*
+      // RS FIXME - MEMCPY variant:
+      // Iterate through each full payload in the buffer.
+      for (std::size_t i = 0; i < full_payloads; ++i) [[likely]] {{
+          // Create a local instance to hold the extracted payload.
+          TargetPayloadType payload;
+  
+          // Copy the raw bytes into our strongly typed payload object.
+          // This assumes payload is trivially copyable or POD-like. 
+          //   - RS FIXME: TBD to ensure or ommit type safety in the plugin's design 
+          // Note: Using std::memcpy avoids undefined behavior from strict aliasing.
+          std::memcpy(&payload, message + i * payload_size, payload_size);
+  
+          if (m_callback_mode) {
+              // Callback mode: directly pass the payload to a sink callback.
+              // Using std::move allows for efficient transfer if payload supports move semantics.
+              (*m_sink_callback)(std::move(payload));
+          } else {
+              // Queue mode: attempt to enqueue the payload in a non-blocking way.
+              if (!m_sink_queue->try_send(std::move(payload), iomanager::Sender::s_no_block)) {
+                  // Queue is full or unavailable: record a dropped packet.
+                  ++m_dropped_packets;  // total drop counter
+              }
+          }
       }
+*/  
 
-    } else {
-      TargetPayloadType target_payload;
-      uint32_t bytes_copied = 0;
-      datahandlinglibs::buffer_copy(message, size, static_cast<void*>(&target_payload), bytes_copied, sizeof(target_payload));
-    }
-
-    return true;
+      // If we received bytes that don't form a complete payload...
+      if (leftover_bytes > 0) {
+          // RS FIXME: Record this as a bad DAQ stream payload for monitoring/statistics purposes.
+          //++m_bad_daq_stream_payload_count;
+      }
+  
+      // Function result: true only if:
+      // - No leftover bytes remained (i.e., input perfectly aligned to payload size)
+      return leftover_bytes == 0;
   }
 
   void generate_opmon_data() override {

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -1,5 +1,6 @@
 #include <time.h>
 #include <rte_arp.h>
+#include <rte_ethdev.h>
 
 namespace dunedaq {
 namespace dpdklibs {
@@ -10,7 +11,7 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
   // Timespec for opportunistic sleep. Nanoseconds configured in conf.
 	struct timespec sleep_request = { 0, (long)m_lcore_sleep_ns };
 
-  bool once = true; // One shot action variable.
+  //bool once = true; // One shot action variable.
   uint16_t iface = m_iface_id;
 
   const uint16_t lid = rte_lcore_id();
@@ -48,21 +49,22 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
       // We got packets from burst on this queue
       if (nb_rx != 0) [[likely]] {
 
+        // Update max burst size counter of this queue
         m_max_burst_size[src_rx_q] = std::max(nb_rx, m_max_burst_size[src_rx_q].load());
+
         // -------
 	      // Iterate on burst packets
         for (int i_b=0; i_b<nb_rx; ++i_b) {
 
-/*
           // Check if packet is segmented. Implement support for it if needed.
-          if (q_bufs[i_b]->nb_segs > 1) [[unlikely]] {
-	          //TLOG_DEBUG(10) << "It appears a packet is spread across more than one receiving buffer;" 
-            //               << " there's currently no logic in this program to handle this";
-	        }
+          //if (q_bufs[i_b]->nb_segs > 1) [[unlikely]] {
+	        //  TLOG_DEBUG(10) << "It appears a packet is spread across more than one receiving buffer;" 
+          //                 << " there's currently no logic in this program to handle this";
+	        //}
 
-          // Check packet type, ommit/drop unexpected ones.
+          // Check packet type, decide their fate: ignore unexpected ones, FIXME: monitor occurrences
           auto pkt_type = q_bufs[i_b]->packet_type;
-          //// Handle non IPV4 packets
+          // Handle non IPV4 frames.
           if (not RTE_ETH_IS_IPV4_HDR(pkt_type)) [[unlikely]] {
             //TLOG_DEBUG(10) << "Non-Ethernet packet type: " << (unsigned)pkt_type << " original: " << pkt_type;
             if (pkt_type == RTE_PTYPE_L2_ETHER_ARP) {
@@ -75,19 +77,25 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
             }
             continue;
           }
-*/
 
-          // Check for UDP frames
-          //if (pkt_type == RTE_PTYPE_L4_UDP) { // RS FIXME: doesn't work. Why? What is the PKT_TYPE in our ETH frames?
-          // Check for JUMBO frames
-          if (q_bufs[i_b]->pkt_len > 1500) [[likely]] { // RS FIXME: do proper check on data length later
-            // Handle them!
+          // Check if frame is non UDP: in that case, ignore it.
+          if ((pkt_type & RTE_PTYPE_L4_MASK) != RTE_PTYPE_L4_UDP) [[unlikely]] {
+            continue; // ommit it
+          }
+
+          // Check for JUMBO frames (bigger than 1500 Bytes)
+					if (q_bufs[i_b]->pkt_len > 1500) [[likely]] { // RS FIXME: do proper check on data length later
+
+            // Get length of user payload. (Ethernet headers excluded.)
             std::size_t data_len = q_bufs[i_b]->data_len;
 
+            // If flow enabled, handle the payload.
             if ( m_lcore_enable_flow.load() ) [[likely]] {
               char* message = udp::get_udp_payload(q_bufs[i_b]);
               handle_eth_payload(src_rx_q, message, data_len);
             }
+
+            // Update metrics of queue: frame and Byte counters
             ++m_num_frames_rxq[src_rx_q];
             m_num_bytes_rxq[src_rx_q] += data_len;
           }
@@ -96,9 +104,8 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
         // Bulk free of mbufs
         rte_pktmbuf_free_bulk(q_bufs, nb_rx);
 
-        // -------
-        
       } // per burst
+      // -----------
 
       // Full burst counter
       if (nb_rx == m_burst_size) {
@@ -128,7 +135,7 @@ IfaceWrapper::arp_response_runner(void *arg __rte_unused) {
   // Timespec for opportunistic sleep. Nanoseconds configured in conf.
   struct timespec sleep_request = { 0, (long)900000 };
 
-  bool once = true; // One shot action variable.
+  //bool once = true; // One shot action variable.
   uint16_t iface = m_iface_id;
 
   const uint16_t lid = rte_lcore_id();

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -75,11 +75,13 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
               //TLOG_DEBUG(10) << "Unidentified! Dumping...";
               //rte_pktmbuf_dump(stdout, q_bufs[i_b], m_bufs[src_rx_q][i_b]->pkt_len);
             }
+            ++m_num_unhandled_non_ipv4[lid];
             continue;
           }
 
           // Check if frame is non UDP: in that case, ignore it.
           if ((pkt_type & RTE_PTYPE_L4_MASK) != RTE_PTYPE_L4_UDP) [[unlikely]] {
+            ++m_num_unhandled_non_udp[lid];
             continue; // ommit it
           }
 
@@ -98,6 +100,8 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
             // Update metrics of queue: frame and Byte counters
             ++m_num_frames_rxq[src_rx_q];
             m_num_bytes_rxq[src_rx_q] += data_len;
+          } else {
+            ++m_num_unhandled_non_jumbo_udp[lid];
           }
         }
 

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -58,9 +58,9 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
 
           // Check if packet is segmented. Implement support for it if needed.
           //if (q_bufs[i_b]->nb_segs > 1) [[unlikely]] {
-	        //  TLOG_DEBUG(10) << "It appears a packet is spread across more than one receiving buffer;" 
+          //  TLOG_DEBUG(10) << "It appears a packet is spread across more than one receiving buffer;" 
           //                 << " there's currently no logic in this program to handle this";
-	        //}
+	  //}
 
           // Check packet type, decide their fate: ignore unexpected ones, FIXME: monitor occurrences
           auto pkt_type = q_bufs[i_b]->packet_type;
@@ -84,7 +84,7 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
           }
 
           // Check for JUMBO frames (bigger than 1500 Bytes)
-					if (q_bufs[i_b]->pkt_len > 1500) [[likely]] { // RS FIXME: do proper check on data length later
+	  if (q_bufs[i_b]->pkt_len > 1500) [[likely]] { // RS FIXME: do proper check on data length later
 
             // Get length of user payload. (Ethernet headers excluded.)
             std::size_t data_len = q_bufs[i_b]->data_len;

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -60,7 +60,7 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
           //if (q_bufs[i_b]->nb_segs > 1) [[unlikely]] {
           //  TLOG_DEBUG(10) << "It appears a packet is spread across more than one receiving buffer;" 
           //                 << " there's currently no logic in this program to handle this";
-	  //}
+          //}
 
           // Check packet type, decide their fate: ignore unexpected ones, FIXME: monitor occurrences
           auto pkt_type = q_bufs[i_b]->packet_type;
@@ -84,7 +84,7 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
           }
 
           // Check for JUMBO frames (bigger than 1500 Bytes)
-	  if (q_bufs[i_b]->pkt_len > 1500) [[likely]] { // RS FIXME: do proper check on data length later
+          if (q_bufs[i_b]->pkt_len > 1500) [[likely]] { // RS FIXME: do proper check on data length later
 
             // Get length of user payload. (Ethernet headers excluded.)
             std::size_t data_len = q_bufs[i_b]->data_len;

--- a/src/detail/IfaceWrapper.hxx
+++ b/src/detail/IfaceWrapper.hxx
@@ -80,7 +80,7 @@ IfaceWrapper::rx_runner(void *arg __rte_unused) {
           // Check for UDP frames
           //if (pkt_type == RTE_PTYPE_L4_UDP) { // RS FIXME: doesn't work. Why? What is the PKT_TYPE in our ETH frames?
           // Check for JUMBO frames
-          if (q_bufs[i_b]->pkt_len > 7000) [[likely]] { // RS FIXME: do proper check on data length later
+          if (q_bufs[i_b]->pkt_len > 1500) [[likely]] { // RS FIXME: do proper check on data length later
             // Handle them!
             std::size_t data_len = q_bufs[i_b]->data_len;
 

--- a/test/apps/test_dpdk_stats.cxx
+++ b/test/apps/test_dpdk_stats.cxx
@@ -33,6 +33,8 @@ namespace {
   std::atomic<uint64_t> num_bytes = 0;
   std::atomic<uint64_t> num_errors = 0;
   std::atomic<uint64_t> num_missed = 0; 
+  std::atomic<uint64_t> num_udp_frames = 0;
+  std::atomic<uint64_t> num_jumbo_frames = 0;
 
 } // namespace ""
 
@@ -103,7 +105,9 @@ lcore_main(struct rte_mempool *mbuf_pool)
       TLOG() << " Total packets: " << num_packets
              << " Total bytes: " << num_bytes
              << " Total missed: " << num_missed
-             << " Total errors: " << num_errors;
+             << " Total errors: " << num_errors
+             << " Total UDP frames: " << num_udp_frames.exchange(0)
+             << " Total JUMBO frames: " << num_jumbo_frames.exchange(0);
       // Queue based counters doesn't seem to work neither here neither in module... :((((((
       for( unsigned long i = 0; i < RTE_ETHDEV_QUEUE_STAT_CNTRS; i++ ){
         TLOG() << "HW iface queue[" << i << "] received: " << (uint64_t)iface_stats.q_ipackets[i];
@@ -163,6 +167,17 @@ lcore_main(struct rte_mempool *mbuf_pool)
           }
           continue;
         }
+
+        // Check if frame is UDP. Count them.
+        if ((pkt_type & RTE_PTYPE_L4_MASK) == RTE_PTYPE_L4_UDP) {
+          ++num_udp_frames;
+        }
+
+        // Check for JUMBO frames (bigger than 1500 Bytes)
+        if (bufs[i_b]->pkt_len > 1500) { // RS FIXME: do proper check on data length later 
+          ++num_jumbo_frames;
+        }
+
       }
       rte_pktmbuf_free_bulk(bufs, nb_rx);
     }


### PR DESCRIPTION
Fixes the extraction part of https://github.com/DUNE-DAQ/dpdklibs/issues/165

- Adds scatter algorithm (multiple payload within same JUMBO frame) which is expected from the Hermes TX firmware. (This is a completely valid stream.)
- Enables the packet type check (some NICs don't have this by default ON)
- Introduces statistics on rte_worker states about unhandled Ethernet frames
- Introduces leftover bytes and failed send counters on sources (streams)
- Removal of pointer voodoo in `handle_payload` of SourceModel.

Closes #165

Initiaties another issue: 
https://github.com/DUNE-DAQ/dpdklibs/issues/168