### PR TITLE
Rationalizing stream id checks.

### DIFF
--- a/include/dpdklibs/Issues.hpp
+++ b/include/dpdklibs/Issues.hpp
@@ -39,6 +39,12 @@ ERS_DECLARE_ISSUE(dpdklibs,
                 );
 
 ERS_DECLARE_ISSUE(dpdklibs,
+                  InconsistentSourceIDConfiguration,
+                  "The list of source ids for [" << ifaceid << "] is inconsistent",
+                  ((int)ifaceid)
+                );
+
+ERS_DECLARE_ISSUE(dpdklibs,
                   FailedToRetrieveInterfaceInfo,
                   "Failed to retrieve device info for interfce [" << ifaceid << "]: " << error,
                   ((int)ifaceid)((int)error)

--- a/plugins/DPDKReaderModule.cpp
+++ b/plugins/DPDKReaderModule.cpp
@@ -90,38 +90,39 @@ tokenize(std::string const& str, const char delim, std::vector<std::string>& out
 void
 DPDKReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcfg )
 {
- auto mdal = mcfg->get_dal<appmodel::DataReaderModule>(get_name());
- m_cfg = mcfg;
- if (mdal->get_outputs().empty()) {
-   auto err = datahandlinglibs::InitializationError(ERS_HERE, "No outputs defined for NIC reader in configuration.");
-   ers::fatal(err);
-   throw err;
- }
-
- for (auto con : mdal->get_outputs()) {
-  auto queue = con->cast<confmodel::QueueWithSourceId>();
-  if(queue == nullptr) {
-	  auto err = datahandlinglibs::InitializationError(ERS_HERE, "Outputs are not of type QueueWithGeoId.");
-	  ers::fatal(err);
-	  throw err;
+  auto mdal = mcfg->get_dal<appmodel::DataReaderModule>(get_name());
+  m_cfg = mcfg;
+  if (mdal->get_outputs().empty()) {
+    auto err = datahandlinglibs::InitializationError(ERS_HERE, "No outputs defined for NIC reader in configuration.");
+    ers::fatal(err);
+    throw err;
   }
 
-  // Check for CB prefix indicating Callback use
-  const char delim = '_';
-  std::string target = queue->UID();
-  std::vector<std::string> words;
-  tokenize(target, delim, words);
-  int sourceid = -1;
+  // Loop over output queues, extract source ids and create source model objects
+  for (auto con : mdal->get_outputs()) {
+    auto queue = con->cast<confmodel::QueueWithSourceId>();
+    if (queue == nullptr) {
+      auto err = datahandlinglibs::InitializationError(ERS_HERE, "Outputs are not of type QueueWithGeoId.");
+      ers::fatal(err);
+      throw err;
+    }
 
-  bool callback_mode = false;
-  if (words.front() == "cb") {
-    callback_mode = true;
+    // Check for CB prefix indicating Callback use
+    const char delim = '_';
+    std::string target = queue->UID();
+    std::vector<std::string> words;
+    tokenize(target, delim, words);
+    int sourceid = -1;
+
+    bool callback_mode = false;
+    if (words.front() == "cb") {
+      callback_mode = true;
+    }
+
+    auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID(), callback_mode);
+    register_node(queue->UID(), ptr);
+    // m_sources[queue->get_source_id()]->init();
   }
-
-  auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID(), callback_mode);
-  register_node( queue->UID(), ptr );
-  //m_sources[queue->get_source_id()]->init(); 
- }
 }
 
 void
@@ -230,7 +231,7 @@ DPDKReaderModule::do_configure(const data_t& /*args*/)
     }
     
     uint iface_id = m_mac_to_id_map[net_device->get_mac_address()];
-    auto ptr = m_ifaces[iface_id] = std::make_shared<IfaceWrapper>(iface_id, dpdk_receiver, nw_senders,  m_sources, m_run_marker);
+    auto ptr = m_ifaces[iface_id] = std::make_shared<IfaceWrapper>(iface_id, dpdk_receiver, nw_senders, m_sources, m_run_marker);
     register_node( fmt::format("interface-{}", iface_id), ptr);
     ptr->allocate_mbufs();
     ptr->setup_interface();

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -67,6 +67,30 @@ IfaceWrapper::IfaceWrapper(
     : m_sources(sources)
     , m_run_marker(run_marker)
 { 
+
+  // Arguments consistency check: collect source ids in senders
+  std::set<int> src_in_d2d;
+  for( auto nw_sender : nw_senders ) {
+    for ( auto det_stream : nw_sender->get_streams() ) {
+      src_in_d2d.insert(det_stream->get_source_id());
+    }
+  }
+
+  // Arguments consistency check: collect source ids in source model map
+  std::set<int> src_models;
+  for( const auto& [src_id, _] : m_sources ) {
+    src_models.insert(src_id);
+  }
+
+  // check that the 2 sets are identical.
+  if (src_in_d2d != src_models) {
+    // TODO : Add set diff to exception
+    // std::vector<int> src_diff;
+    // std::set_symmetric_difference(src_in_d2d.begin(), src_ind2d.end(), src_models.begin(), src_models.end(),
+    //                               std::back_inserter(src_diff));
+    throw InconsistentSourceIDConfiguration(ERS_HERE, m_iface_id);
+  }
+
   auto net_device = receiver->get_uses();
 
   m_iface_id = iface_id;
@@ -122,7 +146,7 @@ IfaceWrapper::IfaceWrapper(
 
   // iterate through active streams
 
-  // Create a map of sender ni (ip) to streams
+  // Create a map of sender ni (ip) to streams from the d2d connection object
   std::map<std::string, std::map<uint, uint>> ip_to_stream_src_groups;
 
   for( auto nw_sender : nw_senders ) {
@@ -130,14 +154,15 @@ IfaceWrapper::IfaceWrapper(
 
     std::string tx_ip = sender_ni->get_ip_address().at(0);
 
+    // Loop over streams
     for ( auto det_stream : nw_sender->get_streams() ) {
 
       uint32_t tx_geo_stream_id = det_stream->get_geo_id()->get_stream_id();
+      // (tx, geo_stream) -> source_id
       ip_to_stream_src_groups[tx_ip][tx_geo_stream_id] = det_stream->get_source_id();
-
     }
-
   }
+
 
 // RS FIXME: Is this RX_Q bump is enough??? I don't remember how the RX_Qs are assigned... 
   uint32_t core_idx(0), rx_q(0); // RS FIXME: Ensure that no RX_Q=0 is used for UDP RX, ever.
@@ -146,6 +171,7 @@ IfaceWrapper::IfaceWrapper(
   m_arp_rx_queue = rx_q;
   ++rx_q;
 
+  // Build additional helper maps
   for( const auto& [tx_ip, strm_src] : ip_to_stream_src_groups) {
     m_ips.insert(tx_ip);
     m_rx_qs.insert(rx_q);
@@ -154,6 +180,7 @@ IfaceWrapper::IfaceWrapper(
 
     m_rx_core_map[m_rte_cores[core_idx]][rx_q] = tx_ip;
     m_stream_id_to_source_id[rx_q] = strm_src;
+    // TLOG() << "+++ ip, rx_q : (" << tx_ip << ", " << rx_q << ") -> " << strm_src;
 
     ++rx_q;
     if ( ++core_idx == m_rte_cores.size()) {
@@ -527,18 +554,21 @@ IfaceWrapper::parse_udp_payload(int src_rx_q, char* payload, std::size_t size)
     // Calculate DAQEth frame size (used both for handling and advancing)
     std::size_t daq_frame_size = sizeof(dunedaq::detdataformats::DAQEthHeader) + data_bytes;
 
-    // Check Source/Stream ID and if its an expected one
-    auto src_id = m_stream_id_to_source_id[src_rx_q][unsigned(daqhdrptr->stream_id)];
-    if ( auto src_it = m_sources.find(src_id); src_it != m_sources.end() ) {
-      src_it->second->handle_daq_frame((char*)daqhdrptr, daq_frame_size);
+    // Check that stream id is corresponds to a registered source
+    auto& strm_to_src = m_stream_id_to_source_id[src_rx_q];
+    // Sadly, cannot take a reference to a bitfield
+    uint strm_id = daqhdrptr->stream_id;
+
+    if ( auto strm_it = strm_to_src.find(strm_id); strm_it != strm_to_src.end() ) {
+      m_sources[strm_id]->handle_daq_frame((char*)daqhdrptr, daq_frame_size);
     } else {
       // Really bad -> unexpeced StreamID in UDP Payload.
       // This check is needed in order to avoid dynamically add thousands
       // of Sources on the fly, in case the data corruption is extremely severe.
-      if (m_num_unexid_frames.count(src_id) == 0) {
-        m_num_unexid_frames[src_id] = 0;
+      if (m_num_unexid_frames.count(strm_id) == 0) {
+        m_num_unexid_frames[strm_id] = 0;
       }
-      m_num_unexid_frames[src_id]++;
+      m_num_unexid_frames[strm_id]++;
     }
       
     // Advance to next payload
@@ -554,19 +584,24 @@ IfaceWrapper::passthrough_udp_payload(int src_rx_q, char* payload, std::size_t s
 {
   // Get DAQ Header and its StreamID
   auto* daqhdrptr = reinterpret_cast<dunedaq::detdataformats::DAQEthHeader*>(payload);
-  auto src_id = m_stream_id_to_source_id[src_rx_q][(unsigned)daqhdrptr->stream_id];
 
-  if ( auto src_it = m_sources.find(src_id); src_it != m_sources.end()) {
-    src_it->second->handle_daq_frame(payload, size);
-  } else {
-    // Really bad -> unexpeced StreamID in UDP Payload.
-    // This check is needed in order to avoid dynamically add thousands
-    // of Sources on the fly, in case the data corruption is extremely severe.
-    if (m_num_unexid_frames.count(src_id) == 0) {
-      m_num_unexid_frames[src_id] = 0;
+    // Check that stream id is corresponds to a registered source
+    auto& strm_to_src = m_stream_id_to_source_id[src_rx_q];
+    
+    // Sadly, cannot take a reference to a bitfield
+    uint strm_id = daqhdrptr->stream_id;
+
+    if ( auto strm_it = strm_to_src.find(strm_id); strm_it != strm_to_src.end() ) {
+      m_sources[strm_id]->handle_daq_frame(payload, size);
+    } else {
+      // Really bad -> unexpeced StreamID in UDP Payload.
+      // This check is needed in order to avoid dynamically add thousands
+      // of Sources on the fly, in case the data corruption is extremely severe.
+      if (m_num_unexid_frames.count(strm_id) == 0) {
+        m_num_unexid_frames[strm_id] = 0;
+      }
+      m_num_unexid_frames[strm_id]++;
     }
-    m_num_unexid_frames[src_id]++;
-  }
 }
 
 } // namespace dpdklibs


### PR DESCRIPTION
The following line in `parse_udp_payload`/`passthrough_udp_payload` doesn't check if the detector stream id is expected before retrieving the source id.
This results in `src_id` being 0 for unknown streams, and in turn in a confusing error message ("Source id 0 not known")
https://github.com/DUNE-DAQ/dpdklibs/blob/df7773db8f82195f68d8b3921b03e03d9384639e/src/IfaceWrapper.cpp#L531
instead of reporting the id of the unknown stream id

This PR tries to solve this issue as follows
1. Added a src_id  consistency check in `IfaceWrapper` constructor. The `DPDKCardReader` receives 2 lists of source ids: one from the d2d connection map and a second from the list of output queues. In principle consistency is guaranteed by the appmodel code that builds the queue, but the module should perform a sanity check on its inputs.
1. Modified the check in `parse_udp_payload`/`passthrough_udp_payload` to verify that the stream_id is know. Once that is ok, the SourceModel object can be pulled w/o any further check since its existence is guaranteed by 1.