### PR TITLE
Johnfreeman/prep release merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(dpdklibs VERSION 2.3.4)
+project(dpdklibs VERSION 2.3.5)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/DPDKReaderModule.cpp
+++ b/plugins/DPDKReaderModule.cpp
@@ -18,6 +18,7 @@
 #include "confmodel/ProcessingResource.hpp"
 #include "confmodel/NetworkDevice.hpp"
 #include "confmodel/QueueWithSourceId.hpp"
+#include "confmodel/DetectorStream.hpp"
 
 #include "logging/Logging.hpp"
 
@@ -214,10 +215,23 @@ DPDKReaderModule::do_configure(const CommandData_t& /*args*/)
 
   for (auto d2d_conn : d2d_conns) {
     auto dpdk_receiver = d2d_conn->get_net_receiver()->cast<appmodel::DPDKReceiver>();
+
+    // Prepare the list of active senders (network transmitters) and active streams
     std::vector<const appmodel::NWDetDataSender*> nw_senders;
+    std::vector<const confmodel::DetectorStream*> active_streams;
+
     for ( auto nw_sender : d2d_conn->get_net_senders() ) {
+      TLOG() << "Sender " << nw_sender->UID() << "is " << nw_sender->is_disabled(*(m_cfg->get_session()));
+
       if ( ! nw_sender->is_disabled(*(m_cfg->get_session())) ) {
         nw_senders.push_back(nw_sender);
+
+        for ( auto det_stream : nw_sender->get_streams() ) {
+          if ( det_stream->is_disabled(*(m_cfg->get_session())) ) 
+            continue;
+          
+          active_streams.push_back(det_stream);
+        }
       }
     }
 
@@ -231,7 +245,7 @@ DPDKReaderModule::do_configure(const CommandData_t& /*args*/)
     }
     
     uint iface_id = m_mac_to_id_map[net_device->get_mac_address()];
-    auto ptr = m_ifaces[iface_id] = std::make_shared<IfaceWrapper>(iface_id, dpdk_receiver, nw_senders, m_sources, m_run_marker);
+    auto ptr = m_ifaces[iface_id] = std::make_shared<IfaceWrapper>(iface_id, dpdk_receiver, nw_senders, active_streams, m_sources, m_run_marker);
     register_node( fmt::format("interface-{}", iface_id), ptr);
     ptr->allocate_mbufs();
     ptr->setup_interface();

--- a/plugins/DPDKReaderModule.cpp
+++ b/plugins/DPDKReaderModule.cpp
@@ -120,6 +120,7 @@ DPDKReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcfg 
       callback_mode = true;
     }
 
+    // TODO: add nullpointer check against misconfiguration
     auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID(), callback_mode);
     register_node(queue->UID(), ptr);
     // m_sources[queue->get_source_id()]->init();

--- a/src/CreateSource.hpp
+++ b/src/CreateSource.hpp
@@ -15,6 +15,7 @@
 #include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
 #include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEEthTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNEEthStreamTypeAdapter.hpp"
 
 #include <memory>
 #include <string>
@@ -80,8 +81,18 @@ createSourceModel(const std::string& conn_uid, bool callback_mode)
     source_model->set_sink(conn_uid, callback_mode);
     
     return source_model;
-  }
+  } else if (raw_dt.find("DAPHNEEthStreamFrame") != std::string::npos) {
+    // WIB2 specific char arrays
+    auto source_model = std::make_shared<SourceModel<fdreadoutlibs::types::DAPHNEEthStreamTypeAdapter>>();
+
+    // For callback acquisition later (lazy)
+    source_model->set_sink_name(conn_uid);
   
+    // Setup sink (acquire pointer from QueueRegistry)
+    source_model->set_sink(conn_uid, callback_mode);
+    
+    return source_model;
+  }  
     
   return nullptr;
 }

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -58,10 +58,19 @@ namespace dpdklibs {
 
 
 //-----------------------------------------------------------------------------
+// TODO: the constructor signature shall be reviewd.
+// The current constructor takes a set of largely correlated arguments
+// - a receiver object
+// - the list of active senders
+// - the list of active streams
+// 
+// These arguments are created by applying the enable mask to detector2daq connection object.
+// They are preferred to the d2d object not to expose the IfaceWrapper code to the System class
 IfaceWrapper::IfaceWrapper(
   uint iface_id,
   const appmodel::DPDKReceiver* receiver,
   const std::vector<const appmodel::NWDetDataSender*>& nw_senders,
+  const std::vector<const confmodel::DetectorStream*>& active_streams,
   sid_to_source_map_t& sources,
   std::atomic<bool>& run_marker
   )
@@ -71,10 +80,9 @@ IfaceWrapper::IfaceWrapper(
 
   // Arguments consistency check: collect source ids in senders
   std::set<int> src_in_d2d;
-  for( auto nw_sender : nw_senders ) {
-    for ( auto det_stream : nw_sender->get_streams() ) {
-      src_in_d2d.insert(det_stream->get_source_id());
-    }
+
+  for( auto& det_stream : active_streams ) {
+    src_in_d2d.insert(det_stream->get_source_id());
   }
 
   // Arguments consistency check: collect source ids in source model map
@@ -86,9 +94,14 @@ IfaceWrapper::IfaceWrapper(
   // check that the 2 sets are identical.
   if (!std::includes(src_models.begin(), src_models.end(), src_in_d2d.begin(), src_in_d2d.end())) {
 
+    // TODO: remove, possibly
+    for ( auto src : src_models ) 
+      TLOG_DEBUG(TLVL_BOOKKEEPING) << "model srcid " << src;
+    for ( auto src : src_in_d2d ) 
+      TLOG_DEBUG(TLVL_BOOKKEEPING) << "d2d srcid " << src;
+
     // D2D sources are not included in the source model list
     // Extract the differences: src_in_d2d - src_models
-
 
     std::vector<int> src_missing;
     std::set_difference(src_models.begin(), src_models.end(),
@@ -170,6 +183,10 @@ IfaceWrapper::IfaceWrapper(
     // Loop over streams
     for ( auto det_stream : nw_sender->get_streams() ) {
 
+      // Only include active streams
+      if ( std::find(active_streams.begin(), active_streams.end(), det_stream) == active_streams.end()) 
+        continue;
+        
       uint32_t tx_geo_stream_id = det_stream->get_geo_id()->get_stream_id();
       // (tx, geo_stream) -> source_id
       ip_to_stream_src_groups[tx_ip][tx_geo_stream_id] = det_stream->get_source_id();

--- a/src/IfaceWrapper.hpp
+++ b/src/IfaceWrapper.hpp
@@ -60,6 +60,7 @@ public:
 
   IfaceWrapper(uint iface_id, const appmodel::DPDKReceiver* receiver,
 	       const std::vector<const appmodel::NWDetDataSender*>& senders,
+	       const std::vector<const confmodel::DetectorStream*>& active_streams,
 	       sid_to_source_map_t& sources, std::atomic<bool>& run_marker);
   ~IfaceWrapper(); 
  


### PR DESCRIPTION
With `fddaq-v5.5.0` now cut, this source branch consists of a fork of the `develop` branch with `prep-release/fddaq-v5.5.0` merged in (i.e., this will be a fast-forward merge which brings the `fddaq-v5.5.0` code into `develop`). Over the weekend a test nightly was created, `MRGFD_DEV_251213_A9`, in which all the `johnfreeman/prep_release_merged` branches were used, and if I `pip install -U . ` the `johnfreeman/prep_release_merged` branch of `drunc`, integration tests with it look fine. 

# Description

_If full decription and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Addresses issue # 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

