### PR TITLE
Remove the DataMoveCallbackRegistry, use IOManager instead 

### DIFF
--- a/plugins/DPDKReaderModule.cpp
+++ b/plugins/DPDKReaderModule.cpp
@@ -108,20 +108,8 @@ DPDKReaderModule::init(const std::shared_ptr<appfwk::ConfigurationManager> mcfg 
       throw err;
     }
 
-    // Check for CB prefix indicating Callback use
-    const char delim = '_';
-    std::string target = queue->UID();
-    std::vector<std::string> words;
-    tokenize(target, delim, words);
-    int sourceid = -1;
-
-    bool callback_mode = false;
-    if (words.front() == "cb") {
-      callback_mode = true;
-    }
-
     // TODO: add nullpointer check against misconfiguration
-    auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID(), callback_mode);
+    auto ptr = m_sources[queue->get_source_id()] = createSourceModel(queue->UID());
     register_node(queue->UID(), ptr);
     // m_sources[queue->get_source_id()]->init();
   }
@@ -270,12 +258,6 @@ DPDKReaderModule::do_configure(const CommandData_t& /*args*/)
 void
 DPDKReaderModule::do_start(const CommandData_t&)
 {
-
-  // Setup callbacks on all sourcemodels
-  for (auto& [sourceid, source] : m_sources) {
-    source->acquire_callback();
-  }
-
   for (auto& [iface_id, iface] : m_ifaces) {
     iface->enable_flow();
   }

--- a/src/CreateSource.hpp
+++ b/src/CreateSource.hpp
@@ -29,7 +29,7 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEEthTypeAdapter, "DAPHNE
 namespace dpdklibs {
 
 std::shared_ptr<SourceConcept>
-createSourceModel(const std::string& conn_uid, bool callback_mode)
+createSourceModel(const std::string& conn_uid)
 {
 
   auto datatypes = dunedaq::iomanager::IOManager::get()->get_datatypes(conn_uid);
@@ -49,7 +49,7 @@ createSourceModel(const std::string& conn_uid, bool callback_mode)
     source_model->set_sink_name(conn_uid);
 
     // Setup sink (acquire pointer from QueueRegistry)
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
 
     // Return with setup model
     return source_model;
@@ -66,7 +66,7 @@ createSourceModel(const std::string& conn_uid, bool callback_mode)
     source_model->set_sink_name(conn_uid);
   
     // Setup sink (acquire pointer from QueueRegistry)
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
     
     return source_model;
 
@@ -78,7 +78,7 @@ createSourceModel(const std::string& conn_uid, bool callback_mode)
     source_model->set_sink_name(conn_uid);
   
     // Setup sink (acquire pointer from QueueRegistry)
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
     
     return source_model;
   } else if (raw_dt.find("DAPHNEEthStreamFrame") != std::string::npos) {
@@ -89,7 +89,7 @@ createSourceModel(const std::string& conn_uid, bool callback_mode)
     source_model->set_sink_name(conn_uid);
   
     // Setup sink (acquire pointer from QueueRegistry)
-    source_model->set_sink(conn_uid, callback_mode);
+    source_model->set_sink(conn_uid);
     
     return source_model;
   }  

--- a/src/SourceConcept.hpp
+++ b/src/SourceConcept.hpp
@@ -37,8 +37,7 @@ namespace dunedaq {
       SourceConcept& operator=(SourceConcept&&) = delete;      ///< SourceConcept is not move-assignable
 
       //  virtual void init(const nlohmann::json& args) = 0;
-      virtual void set_sink(const std::string& sink_name, bool callback_mode) = 0;
-      virtual void acquire_callback() = 0;
+      virtual void set_sink(const std::string& sink_name) = 0;
       //  virtual void conf(const nlohmann::json& args) = 0;
       //  virtual void start(const nlohmann::json& args) = 0;
       //  virtual void stop(const nlohmann::json& args) = 0;

--- a/src/SourceModel.hpp
+++ b/src/SourceModel.hpp
@@ -18,8 +18,6 @@
 
 #include "dpdklibs/opmon/SourceModel.pb.h"
 
-#include "datahandlinglibs/DataMoveCallbackRegistry.hpp"
-
 // #include <folly/ProducerConsumerQueue.h>
 // #include <nlohmann/json.hpp>
 
@@ -48,35 +46,14 @@ public:
   {}
   ~SourceModel() {}
 
-  void set_sink(const std::string& sink_name, bool callback_mode) override
+  void set_sink(const std::string& sink_name) override
   {
-    m_callback_mode = callback_mode;
-    if (callback_mode) {
-      TLOG_DEBUG(5) << "Callback mode requested. Won't acquire iom sender!";
-    } else {
       if (m_sink_is_set) {
         TLOG_DEBUG(5) << "SourceModel sink is already set in initialized!";
       } else {
         m_sink_queue = get_iom_sender<TargetPayloadType>(sink_name);
         m_sink_is_set = true;
       }
-    }
-  }
-
-  void acquire_callback() override
-  {
-    if (m_callback_mode) {
-      if (m_callback_is_acquired) {
-        TLOG_DEBUG(5) << "SourceModel callback is already acquired!";
-      } else {
-        // Getting DataMoveCBRegistry
-        auto dmcbr = datahandlinglibs::DataMoveCallbackRegistry::get();
-        m_sink_callback = dmcbr->get_callback<TargetPayloadType>(inherited::m_sink_name);
-        m_callback_is_acquired = true;
-      }
-    } else {
-      TLOG_DEBUG(5) << "Won't acquire callback, as IOM sink is set!";
-    }
   }
 
   // Exposes sink via returning a pointer to it. 
@@ -105,15 +82,9 @@ public:
       TargetPayloadType frame;
       std::memcpy(&frame, src, m_expected_frame_size);
 
-      if (m_callback_mode) {
-        // Pass by value (moved); no references into 'buffer', so no UAF.
-        (*m_sink_callback)(std::move(frame));
-      } else {
-        // Queue mode: attempt to enqueue the frame in a non-blocking way.
         if (!m_sink_queue->try_send(std::move(frame), iomanager::Sender::s_no_block)) {
            ++m_failed_to_send_daq_payloads;
         }
-      }
     }
   }
 
@@ -138,12 +109,6 @@ private:
   std::string m_sink_id;
   bool m_sink_is_set{ false };
   std::shared_ptr<sink_t> m_sink_queue;
-
-  // Callback internals
-  bool m_callback_mode;
-  bool m_callback_is_acquired{ false };
-  using sink_cb_t = std::shared_ptr<std::function<void(TargetPayloadType&&)>>;
-  sink_cb_t m_sink_callback;
 
   // Stats
   std::atomic<uint64_t> m_leftover_bytes_encountered{0};


### PR DESCRIPTION


# Description

_If full decription and testing details are included on a parent issue, please link to that here._
See https://github.com/DUNE-DAQ/datahandlinglibs/pull/119 for details, requires DUNE-DAQ/iomanager#125

## Type of change

- [x] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

