### PR TITLE
Sbhuller/check allocated xstats

### DIFF
--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -436,67 +436,69 @@ IfaceWrapper::scrap()
 void 
 IfaceWrapper::generate_opmon_data() {
 
-  // Poll stats from HW
-  m_iface_xstats.poll();
+  if(m_iface_xstats.m_allocated) {
+    // Poll stats from HW
+    m_iface_xstats.poll();
 
-  opmon::EthStats s;
-  s.set_ipackets( m_iface_xstats.m_eth_stats.ipackets );
-  s.set_opackets( m_iface_xstats.m_eth_stats.opackets );
-  s.set_ibytes( m_iface_xstats.m_eth_stats.ibytes );
-  s.set_obytes( m_iface_xstats.m_eth_stats.obytes );
-  s.set_imissed( m_iface_xstats.m_eth_stats.imissed );
-  s.set_ierrors( m_iface_xstats.m_eth_stats.ierrors );
-  s.set_oerrors( m_iface_xstats.m_eth_stats.oerrors );
-  s.set_rx_nombuf( m_iface_xstats.m_eth_stats.rx_nombuf );
-  publish( std::move(s) );
+    opmon::EthStats s;
+    s.set_ipackets( m_iface_xstats.m_eth_stats.ipackets );
+    s.set_opackets( m_iface_xstats.m_eth_stats.opackets );
+    s.set_ibytes( m_iface_xstats.m_eth_stats.ibytes );
+    s.set_obytes( m_iface_xstats.m_eth_stats.obytes );
+    s.set_imissed( m_iface_xstats.m_eth_stats.imissed );
+    s.set_ierrors( m_iface_xstats.m_eth_stats.ierrors );
+    s.set_oerrors( m_iface_xstats.m_eth_stats.oerrors );
+    s.set_rx_nombuf( m_iface_xstats.m_eth_stats.rx_nombuf );
+    publish( std::move(s) );
 
-  if(m_iface_xstats.m_eth_stats.imissed > 0){
-    ers::warning(PacketErrors(ERS_HERE, m_iface_id_str, "missed", m_iface_xstats.m_eth_stats.imissed));
-  }
-  if(m_iface_xstats.m_eth_stats.ierrors > 0){
-    ers::warning(PacketErrors(ERS_HERE, m_iface_id_str, "dropped", m_iface_xstats.m_eth_stats.ierrors));
-  }
-
-  // loop over all the xstats information
-  opmon::EthXStatsInfo xinfos;
-  opmon::EthXStatsErrors xerrs;
-  std::map<std::string, opmon::QueueEthXStats> xq;
-
-  for (int i = 0; i < m_iface_xstats.m_len; ++i) {
-    
-    std::string name(m_iface_xstats.m_xstats_names[i].name);
-    
-    // first we select the info from the queue
-    static std::regex queue_regex(R"((rx|tx)_q(\d+)_([^_]+))");
-    std::smatch match;
-    
-    if ( std::regex_match(name, match, queue_regex) ) {
-      auto queue_name = match[1].str() + '-' + match[2].str();
-      auto & entry = xq[queue_name];
-      try {
-	opmonlib::set_value( entry, match[3], m_iface_xstats.m_xstats_values[i] );
-      } catch ( const ers::Issue & e ) {
-	ers::warning( MetricPublishFailed( ERS_HERE, name, e) );
-      }
-      continue;
-    } 
-
-    google::protobuf::Message * metric_p = nullptr;
-    static std::regex err_regex(R"(.+error.*)");
-    if ( std::regex_match( name, err_regex ) ) metric_p = & xerrs;
-    else  metric_p = & xinfos;
-    
-    try { 
-      opmonlib::set_value(*metric_p, name, m_iface_xstats.m_xstats_values[i]);
-    } catch ( const ers::Issue & e ) {
-      ers::warning( MetricPublishFailed( ERS_HERE, name, e) );
+    if(m_iface_xstats.m_eth_stats.imissed > 0){
+      ers::warning(PacketErrors(ERS_HERE, m_iface_id_str, "missed", m_iface_xstats.m_eth_stats.imissed));
     }
+    if(m_iface_xstats.m_eth_stats.ierrors > 0){
+      ers::warning(PacketErrors(ERS_HERE, m_iface_id_str, "dropped", m_iface_xstats.m_eth_stats.ierrors));
+    }
+
+    // loop over all the xstats information
+    opmon::EthXStatsInfo xinfos;
+    opmon::EthXStatsErrors xerrs;
+    std::map<std::string, opmon::QueueEthXStats> xq;
+
+    for (int i = 0; i < m_iface_xstats.m_len; ++i) {
+      
+      std::string name(m_iface_xstats.m_xstats_names[i].name);
+      
+      // first we select the info from the queue
+      static std::regex queue_regex(R"((rx|tx)_q(\d+)_([^_]+))");
+      std::smatch match;
+      
+      if ( std::regex_match(name, match, queue_regex) ) {
+        auto queue_name = match[1].str() + '-' + match[2].str();
+        auto & entry = xq[queue_name];
+        try {
+          opmonlib::set_value( entry, match[3], m_iface_xstats.m_xstats_values[i] );
+        } catch ( const ers::Issue & e ) {
+          ers::warning( MetricPublishFailed( ERS_HERE, name, e) );
+        }
+        continue;
+      } 
+
+      google::protobuf::Message * metric_p = nullptr;
+      static std::regex err_regex(R"(.+error.*)");
+      if ( std::regex_match( name, err_regex ) ) metric_p = & xerrs;
+      else  metric_p = & xinfos;
+      
+      try { 
+        opmonlib::set_value(*metric_p, name, m_iface_xstats.m_xstats_values[i]);
+      } catch ( const ers::Issue & e ) {
+        ers::warning( MetricPublishFailed( ERS_HERE, name, e) );
+      }
+      
+    } // loop over xstats
     
-  } // loop over xstats
-  
-  // Reset HW counters
-  m_iface_xstats.reset_counters();
-  
+    // Reset HW counters
+    m_iface_xstats.reset_counters();
+  }
+
   // finally we publish the information
   publish( std::move(xinfos) );
   publish( std::move(xerrs) );

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -436,11 +436,6 @@ IfaceWrapper::scrap()
 void 
 IfaceWrapper::generate_opmon_data() {
 
-  // initialise xstats info objects
-  opmon::EthXStatsInfo xinfos;
-  opmon::EthXStatsErrors xerrs;
-  std::map<std::string, opmon::QueueEthXStats> xq;
-
   if(m_iface_xstats.m_allocated) {
     // Poll stats from HW
     m_iface_xstats.poll();
@@ -464,6 +459,10 @@ IfaceWrapper::generate_opmon_data() {
     }
 
     // loop over all the xstats information
+    opmon::EthXStatsInfo xinfos;
+    opmon::EthXStatsErrors xerrs;
+    std::map<std::string, opmon::QueueEthXStats> xq;
+
     for (int i = 0; i < m_iface_xstats.m_len; ++i) {
       
       std::string name(m_iface_xstats.m_xstats_names[i].name);
@@ -498,13 +497,12 @@ IfaceWrapper::generate_opmon_data() {
     
     // Reset HW counters
     m_iface_xstats.reset_counters();
-  }
-
-  // finally we publish the information
-  publish( std::move(xinfos) );
-  publish( std::move(xerrs) );
-  for ( auto [id, stat] : xq ) {
-    publish( std::move(stat), {{"queue", id}} );
+    // finally we publish the information
+    publish( std::move(xinfos) );
+    publish( std::move(xerrs) );
+    for ( auto [id, stat] : xq ) {
+      publish( std::move(stat), {{"queue", id}} );
+    }
   }
   
   for( const auto& [src_rx_q,_] : m_num_frames_rxq) {

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -436,6 +436,11 @@ IfaceWrapper::scrap()
 void 
 IfaceWrapper::generate_opmon_data() {
 
+  // initialise xstats info objects
+  opmon::EthXStatsInfo xinfos;
+  opmon::EthXStatsErrors xerrs;
+  std::map<std::string, opmon::QueueEthXStats> xq;
+
   if(m_iface_xstats.m_allocated) {
     // Poll stats from HW
     m_iface_xstats.poll();
@@ -459,10 +464,6 @@ IfaceWrapper::generate_opmon_data() {
     }
 
     // loop over all the xstats information
-    opmon::EthXStatsInfo xinfos;
-    opmon::EthXStatsErrors xerrs;
-    std::map<std::string, opmon::QueueEthXStats> xq;
-
     for (int i = 0; i < m_iface_xstats.m_len; ++i) {
       
       std::string name(m_iface_xstats.m_xstats_names[i].name);


### PR DESCRIPTION
# Description

Adds a check on whether the xstats object have been initialized before sending xstats monitoring objects in generate_opmon_variables. 

_Please also include instructions for how a reviewer can test your changes._
Reviewer take a run with frontend detector electronics.
Can also provide a patch which calls generate opmon variables before the xstats is initialized to ensure this check works.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

