### PR TITLE
stop XStatsHelper in do_scap before the interfaces are stopped.

### DIFF
--- a/include/dpdklibs/XstatsHelper.hpp
+++ b/include/dpdklibs/XstatsHelper.hpp
@@ -82,6 +82,10 @@ namespace dunedaq::dpdklibs {
       }
     }
 
+    void stop() {
+      m_allocated = false;
+    }
+    
     int m_iface_id;
     bool m_allocated = false;
     struct rte_eth_stats m_eth_stats;

--- a/include/dpdklibs/XstatsHelper.hpp
+++ b/include/dpdklibs/XstatsHelper.hpp
@@ -83,6 +83,7 @@ namespace dunedaq::dpdklibs {
     }
 
     void stop() {
+      TLOG() << "Set allocate for xstats helper to false.";
       m_allocated = false;
     }
     

--- a/include/dpdklibs/XstatsHelper.hpp
+++ b/include/dpdklibs/XstatsHelper.hpp
@@ -9,6 +9,10 @@ namespace dunedaq::dpdklibs {
     IfaceXstats(){}
     ~IfaceXstats() 
     {
+      clear();
+    }
+
+    void clear() {
       if (m_xstats_values != nullptr) {
         free(m_xstats_values);
       }
@@ -18,6 +22,7 @@ namespace dunedaq::dpdklibs {
       if (m_xstats_names != nullptr) {
         free(m_xstats_names);
       }
+      m_len = 0;
     }
 
     void setup(int iface) {
@@ -59,11 +64,11 @@ namespace dunedaq::dpdklibs {
         TLOG() << "  XName: " << m_xstats_names[i].name;
       }
 
-      m_allocated = true;
+      m_enabled = true;
     };
 
     void reset_counters() {
-      if (m_allocated) {
+      if (m_enabled) {
         rte_eth_xstats_reset(m_iface_id); //{
         //  TLOG() << "Cannot reset xstat values!";
         //} else { 
@@ -72,7 +77,7 @@ namespace dunedaq::dpdklibs {
     }
 
     void poll() {
-      if (m_allocated) {
+      if (m_enabled) {
         if (m_len != rte_eth_xstats_get_by_id(m_iface_id, nullptr, m_xstats_values, m_len)) {
           TLOG() << "Cannot get xstat values!";
         //} else { 
@@ -83,12 +88,13 @@ namespace dunedaq::dpdklibs {
     }
 
     void stop() {
-      TLOG() << "Set allocate for xstats helper to false.";
-      m_allocated = false;
+      m_enabled = false;
+      clear();
+      TLOG() << "XstatsHelper disabled.";
     }
     
     int m_iface_id;
-    bool m_allocated = false;
+    bool m_enabled = false;
     struct rte_eth_stats m_eth_stats;
     struct rte_eth_xstat_name *m_xstats_names;
     uint64_t *m_xstats_ids;

--- a/plugins/DPDKReaderModule.cpp
+++ b/plugins/DPDKReaderModule.cpp
@@ -279,6 +279,7 @@ DPDKReaderModule::do_scrap(const CommandData_t&)
     set_running(false);
     TLOG() << "Stopping iface wrappers.";
     for (auto& [iface_id, iface] : m_ifaces) {
+      iface->stop_xstats();
       iface->stop();
     }
     ealutils::wait_for_lcores();

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -367,6 +367,15 @@ IfaceWrapper::setup_xstats()
   m_iface_xstats.reset_counters();
 }
 
+//-----------------------------------------------------------------------------
+void
+IfaceWrapper::stop_xstats() 
+{
+  // Stats setup
+  m_iface_xstats.reset_counters();
+  m_iface_xstats.stop();
+}
+
 
 //-----------------------------------------------------------------------------
 void

--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -371,7 +371,7 @@ IfaceWrapper::setup_xstats()
 void
 IfaceWrapper::stop_xstats() 
 {
-  // Stats setup
+  // Stopping stats
   m_iface_xstats.reset_counters();
   m_iface_xstats.stop();
 }
@@ -445,7 +445,7 @@ IfaceWrapper::scrap()
 void 
 IfaceWrapper::generate_opmon_data() {
 
-  if(m_iface_xstats.m_allocated) {
+  if(m_iface_xstats.m_enabled) {
     // Poll stats from HW
     m_iface_xstats.poll();
 

--- a/src/IfaceWrapper.hpp
+++ b/src/IfaceWrapper.hpp
@@ -79,6 +79,7 @@ public:
   void setup_interface();
   void setup_flow_steering();
   void setup_xstats();
+  void stop_xstats();
   
   void enable_flow() { m_lcore_enable_flow.store(true);}
   void disable_flow() { m_lcore_enable_flow.store(false);}


### PR DESCRIPTION
# Description

do scrap is initiated, the inferfaces are stopped correctly in the [DPDKReaderModule](https://github.com/DUNE-DAQ/dpdklibs/blob/136fd72b28c74b4c09377da75ee6bdf23561422a/src/IfaceWrapper.cpp#L408-L424), but not the XstatsHelper. which is used to poll metrics from the interfaces.
[generate_opmon_data is called](https://github.com/DUNE-DAQ/dpdklibs/blob/136fd72b28c74b4c09377da75ee6bdf23561422a/src/IfaceWrapper.cpp#L437-L442), so the XstatsHelper will try to poll metrics from an interface which has already been stopped, so this is the cause of the log messages
```
2026-May-11 14:41:14,090 LOG [void dunedaq::dpdklibs::IfaceXstats::poll() at /tmp/root/spack-stage/spack-stage-dpdklibs-v2.3.6-ayiqjuvypkgnlo5466hs66v3jnqgizd6/spack-src/include/dpdklibs/XstatsHelper.hpp:77] Cannot get xstat values!
Invalid port_id=0
Invalid port_id=0
Invalid port_id=0
```
Fix simply sets the m_allocated flag in the XStatsHelper to false within do_scrap of the DPDKReaderModule, thus preventing metrics to be polled from the interfaces while they are being stopped. 

Can best tested by taking a DAQ run and then calling scrap, and observing whether the readout application crashes. Running with detector hardware is required.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Testing requires detector to check this works.
several runs taken with BDE showed the appropriate message when scrap is initiated, indicating the XStatsHelper has m_allocated set to false. None of the logs mentioned in the description occur and no segmentation faults occured over the various runs.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

