### PR TITLE
disable device reset

### DIFF
--- a/src/IfaceWrapper.cpp
+++ b/src/IfaceWrapper.cpp
@@ -294,7 +294,7 @@ void
 IfaceWrapper::setup_interface()
 {
   TLOG() << "Initialize interface " << m_iface_id;
-  bool with_reset = true, with_mq_mode = true; // go to config
+  bool with_reset = false, with_mq_mode = true; // go to config
   bool check_link_status = false;
 
   int retval = ealutils::iface_init(m_iface_id, m_rx_qs.size(), m_tx_qs.size(), m_rx_ring_size, m_tx_ring_size, m_mbuf_pools, with_reset, with_mq_mode, check_link_status);


### PR DESCRIPTION
# Description

Disable reset of ethernet device when initialising eal interfaces.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

Tested on np02-srv-005 and prevents crashes and server reboot during conf.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

